### PR TITLE
Device Code Authorization Grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ struct ContentView: View {
                 Text("To login, visit")
                 Text(deviceCode.verificationUri).foregroundStyle(.blue)
                 Text("and enter the following code:")
+                Text(deviceCode.userCode)
+                    .padding()
+                    .border(Color.primary)
+                    .font(.title)
             }
         }
         .onChange(of: oauth.state) { _, state in

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ struct ContentView: View {
 }
 ```
 ## tvOS (Device Authorization Grant)
-OAuthKit supports the OAuth 2.0 Device Authorization Grant, which is used by apps that don't have access to a web browser (like tvOS). To leverage OAuthKit in tvOS apps, simply add the `deviceCodeURL` to your OAuth provider and initialize the device authorization grant workflow by calling ```oauth.authorize(provider: provider, grantType: .deviceCode)```
+OAuthKit supports the [OAuth 2.0 Device Authorization Grant](https://alexbilbie.github.io/2016/04/oauth-2-device-flow-grant/), which is used by apps that don't have access to a web browser (like tvOS). To leverage OAuthKit in tvOS apps, simply add the `deviceCodeURL` to your OAuth provider and initialize the device authorization grant workflow by calling ```oauth.authorize(provider: provider, grantType: .deviceCode)```
 
 ![tvOS-screenshot](https://github.com/user-attachments/assets/14997164-f86a-4ee0-b6b7-8c0d9732c83e)
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ struct ContentView: View {
 }
 ```
 ## tvOS (Device Authorization Grant)
-OAuthKit supports the [OAuth 2.0 Device Authorization Grant](https://alexbilbie.github.io/2016/04/oauth-2-device-flow-grant/), which is used by apps that don't have access to a web browser (like tvOS). To leverage OAuthKit in tvOS apps, simply add the `deviceCodeURL` to your OAuth provider and initialize the device authorization grant workflow by calling ```oauth.authorize(provider: provider, grantType: .deviceCode)```
+OAuthKit supports the [OAuth 2.0 Device Authorization Grant](https://alexbilbie.github.io/2016/04/oauth-2-device-flow-grant/), which is used by apps that don't have access to a web browser (like tvOS). To leverage OAuthKit in tvOS apps, simply add the `deviceCodeURL` to your [OAuth.Provider](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L64) and initialize the device authorization grant workflow by calling ```oauth.authorize(provider: provider, grantType: .deviceCode)```
 
 ![tvOS-screenshot](https://github.com/user-attachments/assets/14997164-f86a-4ee0-b6b7-8c0d9732c83e)
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ struct ContentView: View {
     }
 }
 ```
+## tvOS (Device Authorization Grant)
+OAuthKit supports the OAuth 2.0 Device Authorization Grant, which is used by apps that don't have access to a web browser (like tvOS). To leverage OAuthKit in tvOS apps, simply add the `deviceCodeURL` to your OAuth provider and initialize the device authorization grant workflow by calling ```oauth.authorize(provider: provider, grantType: .deviceCode)```
+
+![tvOS-screenshot](https://github.com/user-attachments/assets/14997164-f86a-4ee0-b6b7-8c0d9732c83e)
+
+
 ## OAuthKit Configuration
 By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [EnvironmentObject](https://developer.apple.com/documentation/swiftui/environmentobject). You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json).
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ struct ContentView: View {
                 }
             }
         }
-        .onChange(of: oauth.state) { state, _ in
+        .onChange(of: oauth.state) { _, state in
             handle(state: state)
         }
     }

--- a/Sources/OAuthKit/Extensions/URLRequest+Extensions.swift
+++ b/Sources/OAuthKit/Extensions/URLRequest+Extensions.swift
@@ -19,7 +19,7 @@ public extension URLRequest {
         switch oath.state {
         case .authorized(let auth):
             addValue("\(bearer) \(auth.token.accessToken)", forHTTPHeaderField: authHeader)
-        case .empty, .authorizing, .requestingAccessToken:
+        case .empty, .authorizing, .requestingAccessToken, .requestingDeviceCode, .receivedDeviceCode:
             debugPrint("⚠️ [OAuth is not authorized]")
         }
     }

--- a/Sources/OAuthKit/Extensions/URLResponse+Extensions.swift
+++ b/Sources/OAuthKit/Extensions/URLResponse+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  URLResponse+Extensions.swift
+//  OAuthKit
+//
+//  Created by Kevin McKee
+//
+
+import Foundation
+
+public extension URLResponse {
+
+    /// Returns true if the response status code is in the 200's.
+    var isOK: Bool {
+        if let code = statusCode()  {
+            return 200...299 ~= code
+        }
+        return false
+    }
+
+    /// Extracts the status code from the response.
+    func statusCode() -> Int? {
+        if let httpResponse = self as? HTTPURLResponse {
+            return httpResponse.statusCode
+        }
+        return nil
+    }
+}
+

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -521,21 +521,18 @@ public extension OAuth {
         }
     }
 
-    /// Polls the oauth provider's access token endpoint until the device code has expired or we've received a
+    /// Polls the oauth provider's access token endpoint until the device code has expired or we've successfully received an auth token.
+    /// See: https://oauth.net/2/grant-types/device-code/
     /// - Parameters:
     ///   - provider: the provider to poll
     ///   - deviceCode: the device code to use
     private func poll(provider: Provider, deviceCode: DeviceCode) async {
 
-        guard !deviceCode.isExpired else {
+        guard !deviceCode.isExpired, var urlComponents = URLComponents(string: provider.accessTokenURL.absoluteString) else {
             publish(state: .empty)
             return
         }
 
-        guard var urlComponents = URLComponents(string: provider.accessTokenURL.absoluteString) else {
-            publish(state: .empty)
-            return
-        }
         var queryItems = [URLQueryItem]()
         queryItems.append(URLQueryItem(name: "client_id", value: provider.clientID))
         queryItems.append(URLQueryItem(name: "grant_type", value: "urn:ietf:params:oauth:grant-type:device_code"))

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -189,7 +189,7 @@ public final class OAuth: NSObject {
             case interval
         }
 
-        /// Returns true if the device code is expired or not.
+        /// Returns true if the device code is expired.
         public var isExpired: Bool {
             guard let expiresIn = expiresIn else { return false }
             return issued.addingTimeInterval(Double(expiresIn)) < Date.now
@@ -223,7 +223,7 @@ public final class OAuth: NSObject {
             self.issued = issued
         }
 
-        /// Returns true if the token is expired or not.
+        /// Returns true if the token is expired.
         public var isExpired: Bool {
             guard let expiresIn = token.expiresIn else { return false }
             return issued.addingTimeInterval(Double(expiresIn)) < Date.now

--- a/Sources/OAuthKit/Views/OAWebView.swift
+++ b/Sources/OAuthKit/Views/OAWebView.swift
@@ -56,7 +56,6 @@ extension OAWebView: NSViewRepresentable {
     }
 
     public func updateNSView(_ nsView: NSViewType, context: Context) {
-        debugPrint("✅ [Pushing state]", oauth.state)
         context.coordinator.update(state: oauth.state)
     }
 }

--- a/Tests/OAuthKitTests/CodableTests.swift
+++ b/Tests/OAuthKitTests/CodableTests.swift
@@ -32,7 +32,12 @@ struct CodableTests {
 
         let data = try encoder.encode(deviceCode)
         let decoded: OAuth.DeviceCode = try decoder.decode(OAuth.DeviceCode.self, from: data)
-        #expect(deviceCode == decoded)
+        #expect(deviceCode.deviceCode == decoded.deviceCode)
+        #expect(deviceCode.userCode == decoded.userCode)
+        #expect(deviceCode.verificationUri == decoded.verificationUri)
+        #expect(deviceCode.verificationUriComplete == decoded.verificationUriComplete)
+        #expect(deviceCode.expiresIn == decoded.expiresIn)
+        #expect(deviceCode.interval == decoded.interval)
     }
 
 

--- a/Tests/OAuthKitTests/CodableTests.swift
+++ b/Tests/OAuthKitTests/CodableTests.swift
@@ -25,4 +25,15 @@ struct CodableTests {
         #expect(token == decoded)
     }
 
+    @Test("Encoding and Decoding Device Codes")
+    func whenDecodingDeviceCodes() async throws {
+
+        let deviceCode: OAuth.DeviceCode = .init(deviceCode: UUID().uuidString, userCode: "ABC-XYZ", verificationUri: "https://example.com/device", expiresIn: 1800, interval: 5)
+
+        let data = try encoder.encode(deviceCode)
+        let decoded: OAuth.DeviceCode = try decoder.decode(OAuth.DeviceCode.self, from: data)
+        #expect(deviceCode == decoded)
+    }
+
+
 }

--- a/Tests/OAuthKitTests/Resources/oauth.json
+++ b/Tests/OAuthKitTests/Resources/oauth.json
@@ -3,6 +3,7 @@
         "id": "GitHub",
         "authorizationURL": "https://github.com/login/oauth/authorize",
         "accessTokenURL": "https://github.com/login/oauth/access_token",
+        "deviceCodeURL": "https://github.com/login/device/code",
         "clientID": "CLIENT_ID",
         "clientSecret": "CLIENT_SECRET",
         "redirectURI": "oauthkit://callback",


### PR DESCRIPTION
# Description

Implements the device code authorization grant workflow to allow tvOS (or any other apps that don't have access to a web browser) to leverage OAuthKit.

The Device Code Authorization Grant Workflow consists of the following:

**1. Request Device Code:**
- The OAuth client initiates the authorization process by sending a request to the provider `deviceCodeURL` with the `clientID `and desired `scopes`. 
- This request returns a device code, a user code, a verification URI, and an interval indicating how often the app should poll for authorization. 
- The user code is displayed to the user, and the verification URI is the URL they should visit in a web browser. 

**2. User Authorization:**
- The user opens the verification URI in a web browser and enters the provided user code.
- The user authenticates with the provider, granting the app the requested permissions. 

**3. App Polling for Authorization:**
- While the user is entering the code, the OAuth client will be polling the `accessTokenURL` endpoint in the background. 
This polling continues until the user completes the authorization, or the device and user codes expire. 
- The `client_id` and `device_code` obtained in step 1 are used in these polling requests. 
- The grant_type must be `urn:ietf:params:oauth:grant-type:device_code`. 

See:
- https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow
- https://www.oauth.com/playground/device-code.html

Fixes #4

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
