### PR TITLE
Google Device Code

### DIFF
--- a/Tests/OAuthKitTests/Resources/oauth.json
+++ b/Tests/OAuthKitTests/Resources/oauth.json
@@ -16,6 +16,7 @@
         "id": "Google",
         "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
         "accessTokenURL": "https://oauth2.googleapis.com/token",
+        "deviceCodeURL": "https://oauth2.googleapis.com/device/code",
         "clientID": "CLIENT_ID",
         "clientSecret": "CLIENT_SECRET",
         "redirectURI": "https://github.com/codefiesta/",


### PR DESCRIPTION
# Description

When using Google as an OAuth2 Provider for Device Code Authorization Grants, Google sends `verification_url` instead of the expected `verification_uri` so we account for both of these values in custom `DeviceCode` decoding.

See [Auth 2.0 for TV and Limited-Input Device Applications &nbsp;|&nbsp; Google for Developers](https://developers.google.com/identity/protocols/oauth2/limited-input-device)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
