### PR TITLE
Ephemeral Keychain Tests

### DIFF
--- a/Sources/OAuthKit/Network/NetworkMonitor.swift
+++ b/Sources/OAuthKit/Network/NetworkMonitor.swift
@@ -32,7 +32,7 @@ private let queueLabel = "oauthkit.NetworkMonitor"
     init() {
         pathMonitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.handle(path: path)
             }
         }

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -66,7 +66,7 @@ public final class OAuth: NSObject {
     @ObservationIgnored
     private let networkMonitor = NetworkMonitor()
     @ObservationIgnored
-    private var keychain: Keychain = .default
+    var keychain: Keychain = .default
 
     /// Combine subscribers.
     @ObservationIgnored

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -344,7 +344,7 @@ fileprivate extension OAuth {
         }
 
         // Decode the token
-        guard let token = try? decoder.decode(Token.self, from: data) else {
+        guard response.isOK, let token = try? decoder.decode(Token.self, from: data) else {
             return publish(state: .empty)
         }
 

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -88,9 +88,7 @@ public final class OAuth: NSObject {
             // Override the keychain to use the custom application tag
             self.keychain = .init(applicationTag)
         }
-        Task {
-            await start()
-        }
+        start()
     }
 
     /// Common Initializer that attempts to load an `oauth.json` file from the specified bundle.
@@ -106,9 +104,7 @@ public final class OAuth: NSObject {
             // Override the keychain to use the custom application tag
             self.keychain = .init(applicationTag)
         }
-        Task {
-            await start()
-        }
+        start()
     }
 }
 
@@ -194,13 +190,13 @@ private extension OAuth {
     }
 
     /// Performs post init operations.
-    func start() async {
+    func start() {
         subscribe()
-        await restore()
+        restore()
     }
 
     /// Restores state from storage.
-    func restore() async {
+    func restore() {
         for provider in providers {
             if let authorization: OAuth.Authorization = try? keychain.get(key: provider.id), !authorization.isExpired {
                 publish(state: .authorized(provider, authorization))

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -154,7 +154,7 @@ public extension OAuth {
     ///   - code: the code to exchange
     ///   - pkce: the pkce data
     func token(provider: Provider, code: String, pkce: PKCE? = nil) {
-        Task {
+        Task(priority: .high) {
             let result = await requestToken(provider: provider, code: code, pkce: pkce)
             switch result {
             case .success(let token):

--- a/Tests/OAuthKitTests/KeychainTests.swift
+++ b/Tests/OAuthKitTests/KeychainTests.swift
@@ -10,14 +10,21 @@ import Testing
 
 @Suite("Keychain Tests", .tags(.keychain))
 final class KeychainTests {
+    
+    let keychain: Keychain
 
     deinit {
-        Keychain.default.clear()
+        keychain.clear()
     }
-
+    
+    /// Initializer.
+    init() async throws {
+        let tag: String = "oauthkit.test." + .secureRandom()
+        keychain = .init(tag)
+    }
+    
     @Test("Storing keychain values")
     func whenStoring() async throws {
-        let keychain: Keychain = .init("oauth-token.test")
         let key = "Github"
         let token: OAuth.Token = .init(accessToken: "1234", refreshToken: nil, expiresIn: 3600, scope: "email", type: "Bearer")
 
@@ -32,9 +39,10 @@ final class KeychainTests {
         #expect(token.scope == found.scope)
         #expect(token.type == found.type)
 
-        let keys = keychain.keys.filter{ $0.contains("oauth")}
+        let keys = keychain.keys
+
         debugPrint("🔐", keys)
-        #expect(keys.count > 0)
+        #expect(keys.count == 1)
 
         let deleted = keychain.delete(key: key)
         #expect(deleted == true)

--- a/Tests/OAuthKitTests/KeychainTests.swift
+++ b/Tests/OAuthKitTests/KeychainTests.swift
@@ -40,7 +40,6 @@ final class KeychainTests {
         #expect(token.type == found.type)
 
         let keys = keychain.keys
-
         debugPrint("🔐", keys)
         #expect(keys.count == 1)
 

--- a/Tests/OAuthKitTests/KeychainTests.swift
+++ b/Tests/OAuthKitTests/KeychainTests.swift
@@ -10,19 +10,19 @@ import Testing
 
 @Suite("Keychain Tests", .tags(.keychain))
 final class KeychainTests {
-    
+
     let keychain: Keychain
 
     deinit {
         keychain.clear()
     }
-    
+
     /// Initializer.
     init() async throws {
         let tag: String = "oauthkit.test." + .secureRandom()
         keychain = .init(tag)
     }
-    
+
     @Test("Storing keychain values")
     func whenStoring() async throws {
         let key = "Github"

--- a/Tests/OAuthKitTests/OAuth+Monitor.swift
+++ b/Tests/OAuthKitTests/OAuth+Monitor.swift
@@ -11,7 +11,7 @@ import Foundation
 extension OAuth {
 
     /// Provides a testing utility to stream an oauth state until it's received an authorization.
-    /// This is necessary because often a unit test will die as an  asynchronous request is received that
+    /// This is necessary because a unit test can potentially die as an asynchronous request is received that
     /// inserts an authorization record into the keychain. This allows us to keep the keychain clean and not get littered with test records.
     @MainActor
     class Monitor {

--- a/Tests/OAuthKitTests/OAuth+Monitor.swift
+++ b/Tests/OAuthKitTests/OAuth+Monitor.swift
@@ -1,0 +1,56 @@
+//
+//  OAuth+Monitor.swift
+//  OAuthKit
+//
+//  Created by Kevin McKee on 6/6/25.
+//
+
+import Foundation
+@testable import OAuthKit
+
+extension OAuth {
+
+    /// Provides a testing utility to stream an oauth state until it's received an authorization.
+    /// This is necessary because often a unit test will die as an  asynchronous request is received that
+    /// inserts an authorization record into the keychain. This allows us to keep the keychain clean and not get littered with test records.
+    @MainActor
+    class Monitor {
+
+        typealias OAuthStateAsyncStream = AsyncStream<OAuth.State>
+
+        private let oauth: OAuth
+
+        var continuation: OAuthStateAsyncStream.Continuation?
+
+        lazy var stream: OAuthStateAsyncStream = {
+            AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+                self.continuation = continuation
+                waitForNextValue()
+            }
+        }()
+
+        /// Initialzation.
+        /// - Parameter oauth: the oauth state to stream
+        init(oauth: OAuth) {
+            self.oauth = oauth
+        }
+
+        deinit {
+            continuation?.finish()
+        }
+
+        /// Waits for the next state value to be received. This will continue until we've received an `.authorized` state.
+        private func waitForNextValue() {
+            Task {
+                let state = oauth.state
+                continuation?.yield(state)
+                switch state {
+                case .empty, .authorizing, .requestingAccessToken, .requestingDeviceCode, .receivedDeviceCode:
+                    waitForNextValue()
+                case .authorized(_, _):
+                    continuation?.finish()
+                }
+            }
+        }
+    }
+}

--- a/Tests/OAuthKitTests/OAuthTestURLProtocol.swift
+++ b/Tests/OAuthKitTests/OAuthTestURLProtocol.swift
@@ -40,7 +40,7 @@ private actor OAuthTestRequestHandler {
 
         // Returns oauth access token data
         if url.absoluteString.contains("token") {
-            let token: OAuth.Token = .init(accessToken: .secureRandom(), refreshToken: nil, expiresIn: 3600, scope: nil, type: "Bearer")
+            let token: OAuth.Token = .init(accessToken: .secureRandom(), refreshToken: .secureRandom(), expiresIn: 3600, scope: nil, type: "Bearer")
             return try! JSONEncoder().encode(token)
         }
 

--- a/Tests/OAuthKitTests/OAuthTestWKNavigationAction.swift
+++ b/Tests/OAuthKitTests/OAuthTestWKNavigationAction.swift
@@ -27,12 +27,6 @@ final class OAuthTestWKNavigationAction: WKNavigationAction {
         super.init()
     }
 
-    /// Initializer with url
-    /// - Parameter url: the url
-    convenience init(url: URL) {
-        self.init(urlRequest: URLRequest(url: url))
-    }
-
     /// Returns the received decision policy
     /// - Parameter policy: the navigation action policy
     func decisionHandler(_ policy: WKNavigationActionPolicy) {

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -169,7 +169,11 @@ final class OAuthTests {
         #expect(request!.url!.absoluteString.contains("client_id="))
         #expect(request!.url!.absoluteString.contains("grant_type=refresh_token"))
         #expect(request!.url!.absoluteString.contains("refresh_token=\(token.refreshToken!)"))
+        let auth: OAuth.Authorization = .init(issuer: provider.id, token: token)
+        try! keychain.set(auth, for: provider.id)
         oauth.authorize(provider: provider, grantType: .refreshToken)
+        let result = await waitForAuthorization()
+        #expect(result == true)
     }
 
     /// Tests the PKCE request parameters.

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -6,8 +6,8 @@
 //
 import Foundation
 @testable import OAuthKit
-import Testing
 import Observation
+import Testing
 
 @MainActor
 @Suite("OAuth Tests", .tags(.oauth))
@@ -31,7 +31,7 @@ final class OAuthTests {
         oauth = .init(.module, options: options)
         // Override the url session
         oauth.urlSession = urlSession
-        
+
         let keychain: Keychain = .init(applicationTag)
         withObservationTracking {
             _ = oauth.state


### PR DESCRIPTION
# Description

The Keychain + OAuth tests were leaving behind clutter in the `Keychain` and also potentially overwriting production values that may have been set by the application. This fix includes:

- Using a custom `applicationTag` that will only set and delete values for keychain items with that tag.
- Fixes the deletion result for clearing a `Keychain`.
- Sets the OAuth task priorities as `.high`.
- The OAuth `.init` is now completely synchronous to avoid restoration state updates during tests.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
