### PR TITLE
PKCE Optional Client Secret

### DIFF
--- a/Sources/OAuthKit/OAuth+Provider.swift
+++ b/Sources/OAuthKit/OAuth+Provider.swift
@@ -25,7 +25,7 @@ extension OAuth {
         /// The unique client identifier tforinteracting with this providers oauth server.
         var clientID: String
         /// The client's secret known only to the client and the providers oauth server. It is essential the client's password.
-        var clientSecret: String
+        var clientSecret: String?
         /// The provider redirect uri.
         var redirectURI: String?
         /// The provider scopes.
@@ -108,7 +108,7 @@ extension OAuth {
             accessTokenURL = try container.decode(URL.self, forKey: .accessTokenURL)
             deviceCodeURL = try container.decodeIfPresent(URL.self, forKey: .deviceCodeURL)
             clientID = try container.decode(String.self, forKey: .clientID)
-            clientSecret = try container.decode(String.self, forKey: .clientSecret)
+            clientSecret = try container.decodeIfPresent(String.self, forKey: .clientSecret)
             redirectURI = try container.decodeIfPresent(String.self, forKey: .redirectURI)
             scope = try container.decodeIfPresent([String].self, forKey: .scope)
             encodeHttpBody = try container.decodeIfPresent(Bool.self, forKey: .encodeHttpBody) ?? true

--- a/Sources/OAuthKit/OAuth+Provider.swift
+++ b/Sources/OAuthKit/OAuth+Provider.swift
@@ -77,7 +77,7 @@ extension OAuth {
                     accessTokenURL: URL,
                     deviceCodeURL: URL? = nil,
                     clientID: String,
-                    clientSecret: String,
+                    clientSecret: String?,
                     redirectURI: String? = nil,
                     scope: [String]? = nil,
                     encodeHttpBody: Bool = true,

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -99,7 +99,7 @@ final class OAuthTests {
         let request = OAuth.Request.device(provider: provider)
         #expect(request != nil)
         #expect(request!.url!.absoluteString.contains("client_id=\(provider.clientID)"))
-        #expect(request!.url!.absoluteString.contains("client_secret=\(provider.clientSecret)"))
+        #expect(request!.url!.absoluteString.contains("client_secret=\(provider.clientSecret!)"))
         #expect(request!.url!.absoluteString.contains("grant_type=device_code"))
         oauth.authorize(provider: provider, grantType: .deviceCode)
     }
@@ -127,7 +127,7 @@ final class OAuthTests {
         #expect(request != nil)
         #expect(data != nil)
         #expect(stringData!.contains("client_id=\(provider.clientID)"))
-        #expect(stringData!.contains("client_secret=\(provider.clientSecret)"))
+        #expect(stringData!.contains("client_secret=\(provider.clientSecret!)"))
         #expect(stringData!.contains("code=\(code)"))
         #expect(stringData!.contains("redirect_uri=\(provider.redirectURI!)"))
         #expect(stringData!.contains("grant_type=authorization_code"))
@@ -148,7 +148,9 @@ final class OAuthTests {
         #expect(request != nil)
         #expect(data != nil)
         #expect(stringData!.contains("client_id=\(provider.clientID)"))
-        #expect(stringData!.contains("client_secret=\(provider.clientSecret)"))
+        if let clientSecret = provider.clientSecret {
+            #expect(stringData!.contains("client_secret=\(clientSecret)"))
+        }
         #expect(stringData!.contains("code=\(code)"))
         #expect(stringData!.contains("redirect_uri=\(provider.redirectURI!)"))
         #expect(stringData!.contains("grant_type=authorization_code"))


### PR DESCRIPTION
# Description

Optional **client_secret** for clients who only wish to use [PKCE](https://www.rfc-editor.org/rfc/rfc7636#section-4.2) Flow with no provisioned client_secret. This will allow developers to create OAuth Providers with optional client secrets (if not provisioned).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
