### PR TITLE
Dynamic Badge

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -41,4 +41,3 @@ jobs:
         label: Coverage
         message: ${{steps.coverage.outputs.percentage}}%
         color: white
-        forceUpdate: true


### PR DESCRIPTION
# Description

Removes the `forceUpdate` flag for the dynamic badge Code Coverage workflow action as there is no reason to update the gist output if the content hasn't changed.