### PR TITLE
OAWebView Initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,18 @@ import SwiftUI
 @main
 struct OAuthApp: App {
 
+    let oauth: OAuth = .init(.main)
+    
     /// Build the scene body
     var body: some Scene {
 
         WindowGroup {
             ContentView()
         }
+        .environment(\.oauth, oauth)
         
         WindowGroup(id: "oauth") {
-            OAWebView()
+            OAWebView(oauth: oauth)
         }
     }
 } 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ import SwiftUI
 @main
 struct OAuthApp: App {
 
+    /// The observable oauth object 
     let oauth: OAuth = .init(.main)
     
     /// Build the scene body

--- a/Sources/OAuthKit/Views/OAWebView.swift
+++ b/Sources/OAuthKit/Views/OAWebView.swift
@@ -14,12 +14,14 @@ import WebKit
 @MainActor
 public struct OAWebView {
 
-    @Environment(\.oauth)
-    var oauth: OAuth
+    let oauth: OAuth
     let view = WKWebView()
 
-    /// Public Initializer.
-    public init() { }
+    /// Initializer with the speciifed oauth object,
+    /// - Parameter oauth: the oauth object to use
+    public init(oauth: OAuth = .init(.main)) {
+        self.oauth = oauth
+    }
 
     public func makeWebView(context: Context) -> WKWebView {
         view.navigationDelegate = context.coordinator

--- a/Sources/OAuthKit/Views/OAWebView.swift
+++ b/Sources/OAuthKit/Views/OAWebView.swift
@@ -19,7 +19,7 @@ public struct OAWebView {
 
     /// Initializer with the speciifed oauth object,
     /// - Parameter oauth: the oauth object to use
-    public init(oauth: OAuth = .init(.main)) {
+    public init(oauth: OAuth) {
         self.oauth = oauth
     }
 

--- a/Sources/OAuthKit/Views/OAWebViewCoordinator.swift
+++ b/Sources/OAuthKit/Views/OAWebViewCoordinator.swift
@@ -55,10 +55,6 @@ public class OAWebViewCoordinator: NSObject {
             }
             // Exchange the code for a token
             oauth.token(provider: provider, code: code)
-        case .clientCredentials:
-            break
-        case .deviceCode:
-            break
         case .pkce(let pkce):
             // Verify the state
             guard state == pkce.state else {
@@ -70,7 +66,7 @@ public class OAWebViewCoordinator: NSObject {
             }
             // Exchange the code for a token along with the pkce validation data
             oauth.token(provider: provider, code: code, pkce: pkce)
-        case .refreshToken:
+        case .clientCredentials, .deviceCode, .refreshToken:
             break
         }
     }

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -86,11 +86,5 @@ final class OAWebViewTests {
         policy = await coordinator.webView(wkWebView, decidePolicyFor: navigationAction)
         #expect(policy == .allow)
     }
-
-//    @Test("Coordinator State Updates")
-//    func whenCoordinatorHandlesUpdates() async throws {
-//        let coordinator: OAWebViewCoordinator = webView.makeCoordinator()
-//        coordinator.update(state: <#T##OAuth.State#>)
-//    }
 }
 #endif

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -25,10 +25,12 @@ final class OAWebViewTests {
     }()
 
     let oauth: OAuth
+    let webView: OAWebView
 
     /// Initializer.
     init() async throws {
         oauth = .init(.module)
+        webView = .init(oauth: oauth)
         oauth.urlSession = urlSession
     }
 
@@ -42,23 +44,53 @@ final class OAWebViewTests {
         #expect(environmentOAuth == oauth)
     }
 
-    /// Tests the OAWebViewCoordinator coordinator policy decision.
-    /// TODO: This is fairly limited at the moment because we will receive errors
-    /// about accessing the `oauth` environment outside of being installed on a view.
-    /// Needs more investigation for testing SwiftUI views.
+    /// Tests the OAWebViewCoordinator coordinator policy decisions.
     @Test("Coordinator Policy Decisons")
     func whenCoordinatorDecidingPolicy() async throws {
 
-        let webView: OAWebView = .init()
+        // 1) Bad Request Expectations
         let coordinator: OAWebViewCoordinator = webView.makeCoordinator()
+        #expect(coordinator.oauth == oauth)
         let wkWebView = webView.view
 
         var urlRequest: URLRequest = .init(url: URL(string: "https://github.com/codefiesta/OAuthKit")!)
         urlRequest.url = nil
 
-        let navigationAction: WKNavigationAction = OAuthTestWKNavigationAction(urlRequest: urlRequest)
-        let policy = await coordinator.webView(wkWebView, decidePolicyFor: navigationAction)
+        var navigationAction: WKNavigationAction = OAuthTestWKNavigationAction(urlRequest: urlRequest)
+        var policy = await coordinator.webView(wkWebView, decidePolicyFor: navigationAction)
         #expect(policy == .cancel)
+
+        let provider = oauth.providers[0]
+
+        // 2) Authorization Code Expectations
+        let state: String = .secureRandom()
+        let code: String = .secureRandom()
+
+        oauth.authorize(provider: provider, grantType: .authorizationCode(state))
+        coordinator.update(state: oauth.state)
+        var urlString = provider.redirectURI! + "?code=\(code)&state=\(state)"
+        urlRequest = .init(url: URL(string: urlString)!)
+
+        navigationAction = OAuthTestWKNavigationAction(urlRequest: urlRequest)
+        policy = await coordinator.webView(wkWebView, decidePolicyFor: navigationAction)
+        #expect(policy == .allow)
+
+        // 3) PKCE Expectations
+        let pkce: OAuth.PKCE = .init()
+        oauth.authorize(provider: provider, grantType: .pkce(pkce))
+        coordinator.update(state: oauth.state)
+        urlString = provider.redirectURI! + "?code=\(code)&state=\(pkce.state)"
+        urlRequest = .init(url: URL(string: urlString)!)
+
+        navigationAction = OAuthTestWKNavigationAction(urlRequest: urlRequest)
+        policy = await coordinator.webView(wkWebView, decidePolicyFor: navigationAction)
+        #expect(policy == .allow)
     }
+
+//    @Test("Coordinator State Updates")
+//    func whenCoordinatorHandlesUpdates() async throws {
+//        let coordinator: OAWebViewCoordinator = webView.makeCoordinator()
+//        coordinator.update(state: <#T##OAuth.State#>)
+//    }
 }
 #endif


### PR DESCRIPTION
# Description

Fixes #70


The `OAWebView` is now being explicitly initialized with an OAuth object. This change is intended to do the following:
- Increase test code coverage
- Reduce potential bugs and developer confusion over the magic of which OAuth configuration is being used inside the `OAWebView`.

⚠️ This is a breaking change that forces developers to change the following:
```swift
 WindowGroup(id: "oauth") {
    OAWebView()
}
```
to 
```swift
 WindowGroup(id: "oauth") {
    OAWebView(oauth: oauth)
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
