### PR TITLE
GitHub Default Test Provider

### DIFF
--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -26,6 +26,9 @@ final class OAWebViewTests {
 
     let oauth: OAuth
     let webView: OAWebView
+    var provider: OAuth.Provider {
+        oauth.providers.filter{ $0.id == "GitHub" }.first!
+    }
 
     /// Initializer.
     init() async throws {
@@ -59,8 +62,6 @@ final class OAWebViewTests {
         var navigationAction: WKNavigationAction = OAuthTestWKNavigationAction(urlRequest: urlRequest)
         var policy = await coordinator.webView(wkWebView, decidePolicyFor: navigationAction)
         #expect(policy == .cancel)
-
-        let provider = oauth.providers[0]
 
         // 2) Authorization Code Expectations
         let state: String = .secureRandom()
@@ -97,7 +98,6 @@ final class OAWebViewTests {
         let wkWebView = webView.view
 
         var urlRequest: URLRequest = .init(url: URL(string: "https://github.com/codefiesta/OAuthKit")!)
-        let provider = oauth.providers[0]
 
         // 2) Authorization Code Expectations
         let state: String = .secureRandom()

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -17,6 +17,9 @@ final class OAuthTests {
     var keychain: Keychain {
         oauth.keychain
     }
+    var provider: OAuth.Provider {
+        oauth.providers.filter{ $0.id == "GitHub" }.first!
+    }
 
     /// The mock url session that overrides the protocol classes with `OAuthTestURLProtocol`
     /// that will intercept all outbound requests and return mocked test data.
@@ -64,7 +67,6 @@ final class OAuthTests {
     /// Tests the authorization request parameters.
     @Test("Building Authorization Request")
     func whenBuildingAuthorizationRequest() async throws {
-        let provider = oauth.providers[0]
         let state: String = .secureRandom(count: 16)
         let grantType: OAuth.GrantType = .authorizationCode(state)
         let request = OAuth.Request.auth(provider: provider, grantType: grantType)
@@ -78,7 +80,6 @@ final class OAuthTests {
     /// Tests the building of client credential token requests.
     @Test("Building Client Credentials Token Requests")
     func whenBuildingClientCredentialsTokenRequests() async throws {
-        let provider = oauth.providers[0]
         let request = OAuth.Request.token(provider: provider)
         let data = request?.httpBody
         let stringData = String(data: data!, encoding: .utf8)
@@ -95,7 +96,6 @@ final class OAuthTests {
     /// Tests the `/device`code  request parameters.
     @Test("Building Device Code Request")
     func whenBuildingDeviceCodeRequest() async throws {
-        let provider = oauth.providers[0]
         let request = OAuth.Request.device(provider: provider)
         #expect(request != nil)
         #expect(request!.url!.absoluteString.contains("client_id=\(provider.clientID)"))
@@ -107,7 +107,6 @@ final class OAuthTests {
     /// Tests the building of device code token requests.
     @Test("Building Device Code Token Requests")
     func whenBuildingDeviceCodeTokenRequests() async throws {
-        let provider = oauth.providers[0]
         let deviceCode: OAuth.DeviceCode = .init(deviceCode: .secureRandom(), userCode: "ABC-XYZ", verificationUri: "https://example.com/device", expiresIn: 1800, interval: 5)
         let request = OAuth.Request.token(provider: provider, deviceCode: deviceCode)
         #expect(request != nil)
@@ -119,7 +118,6 @@ final class OAuthTests {
     /// Tests the building of token requests.
     @Test("Building Token Requests")
     func whenBuildingTokenRequests() async throws {
-        let provider = oauth.providers[0]
         let code: String = .secureRandom()
         let request = OAuth.Request.token(provider: provider, code: code, pkce: nil)
         let data = request?.httpBody
@@ -139,7 +137,6 @@ final class OAuthTests {
     /// Tests the building of PKCE token requests.
     @Test("Building PKCE Token Requests")
     func whenBuildingPKCETokenRequests() async throws {
-        let provider = oauth.providers[0]
         let code: String = .secureRandom()
         let pkce: OAuth.PKCE = .init()
         let request = OAuth.Request.token(provider: provider, code: code, pkce: pkce)
@@ -163,7 +160,6 @@ final class OAuthTests {
     /// Tests the refresh token request parameters.
     @Test("Building Refresh Token Request")
     func whenBuildingRefreshTokenRequest() async throws {
-        let provider = oauth.providers[0]
         let token: OAuth.Token = .init(accessToken: .secureRandom(), refreshToken: .secureRandom(), expiresIn: 3600, scope: nil, type: "Bearer")
         let request = OAuth.Request.refresh(provider: provider, token: token)
         #expect(request != nil)
@@ -180,7 +176,6 @@ final class OAuthTests {
     /// Tests the PKCE request parameters.
     @Test("Building PKCE Request")
     func whenBuildingPKCERequest() async throws {
-        let provider = oauth.providers[0]
         let pkce: OAuth.PKCE = .init()
         let grantType: OAuth.GrantType = .pkce(pkce)
         let request = OAuth.Request.auth(provider: provider, grantType: grantType)
@@ -221,7 +216,6 @@ final class OAuthTests {
     /// Tests the adding of the Authorization header to an URLRequest.
     @Test("Adding Authorization Header to URLRequest")
     func whenAddingAuthHeader() async throws {
-        let provider = oauth.providers[0]
         let string = "https://github.com/codefiesta/OAuthKit"
         let url = URL(string: string)
         var urlRequest = URLRequest(url: url!)
@@ -240,7 +234,6 @@ final class OAuthTests {
     /// Tests OAuth State changes
     @Test("OAuth State Changes")
     func whenOAuthState() async throws {
-        let provider = oauth.providers[0]
         let state: String = .secureRandom(count: 16)
 
         // Authorization Code

--- a/Tests/OAuthKitTests/Resources/oauth.json
+++ b/Tests/OAuthKitTests/Resources/oauth.json
@@ -1,5 +1,33 @@
 [
     {
+        "id": "Box",
+        "authorizationURL": "https://account.box.com/api/oauth2/authorize",
+        "accessTokenURL": "https://api.box.com/oauth2/token",
+        "clientID": "CLIENT_ID",
+        "clientSecret": "CLIENT_SECRET",
+        "redirectURI": "https://github.com/codefiesta/",
+        "scope": [
+            "root_readwrite"
+        ],
+        "debug": true,
+    },
+    {
+        "id": "Dropbox",
+        "authorizationURL": "https://www.dropbox.com/oauth2/authorize",
+        "accessTokenURL": "https://api.dropboxapi.com/oauth2/token",
+        "clientID": "CLIENT_ID",
+        "clientSecret": "CLIENT_SECRET",
+        "redirectURI": "https://github.com/codefiesta/",
+        "scope": [
+            "email",
+            "profile",
+            "openid",
+            "files.metadata.write",
+            "files.content.write",
+        ],
+        "debug": true,
+    },
+    {
         "id": "GitHub",
         "authorizationURL": "https://github.com/login/oauth/authorize",
         "accessTokenURL": "https://github.com/login/oauth/access_token",
@@ -65,33 +93,5 @@
             "profile",
             "openid"
         ]
-    },
-    {
-        "id": "Box",
-        "authorizationURL": "https://account.box.com/api/oauth2/authorize",
-        "accessTokenURL": "https://api.box.com/oauth2/token",
-        "clientID": "CLIENT_ID",
-        "clientSecret": "CLIENT_SECRET",
-        "redirectURI": "https://github.com/codefiesta/",
-        "scope": [
-            "root_readwrite"
-        ],
-        "debug": true,
-    },
-    {
-        "id": "Dropbox",
-        "authorizationURL": "https://www.dropbox.com/oauth2/authorize",
-        "accessTokenURL": "https://api.dropboxapi.com/oauth2/token",
-        "clientID": "CLIENT_ID",
-        "clientSecret": "CLIENT_SECRET",
-        "redirectURI": "https://github.com/codefiesta/",
-        "scope": [
-            "email",
-            "profile",
-            "openid",
-            "files.metadata.write",
-            "files.content.write",
-        ],
-        "debug": true,
     }
 ]


### PR DESCRIPTION
# Description

It occurred to me when adding the Box + Dropbox templates to the sample oauth.json file that all of the unit tests were relying on the Github provider and always assuming it was the first in the list. 

This change performs a simple filter for the GitHub provider in tests:

```swift

// Old
let provider =  oauth.providers[0]

// New
var provider: OAuth.Provider {
     oauth.providers.filter{ $0.id == "GitHub" }.first!
}
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
