### PR TITLE
VisionOS Keychain

### DIFF
--- a/Sources/OAuthKit/Keychain/Keychain.swift
+++ b/Sources/OAuthKit/Keychain/Keychain.swift
@@ -35,7 +35,6 @@ class Keychain: @unchecked Sendable {
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrApplicationTag as String: applicationTag,
             kSecReturnAttributes as String: true,
             kSecMatchLimit as String: kSecMatchLimitAll
         ]
@@ -77,7 +76,6 @@ class Keychain: @unchecked Sendable {
         let data = try encoder.encode(value)
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrApplicationTag as String: applicationTag,
             kSecAttrAccount as String: account,
             kSecValueData as String: data
         ]
@@ -98,7 +96,6 @@ class Keychain: @unchecked Sendable {
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrApplicationTag as String: applicationTag,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecAttrAccount as String: account,
             kSecReturnData as String: true
@@ -153,7 +150,6 @@ class Keychain: @unchecked Sendable {
     private func deleteNoLock(_ key: String) -> Bool {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrApplicationTag as String: applicationTag,
             kSecAttrAccount as String: key
         ]
         let status = SecItemDelete(query as CFDictionary)


### PR DESCRIPTION
# Description

VisionOS Keychain Doesn't recognize `kSecAttrApplicationTag` attribute and will fail when trying to insert token data into the Keychain if this attribute is set. This PR simply removes the attribute as it wasn't adding any value anyway.

Unfortunately, because VisionOS needs entitlements which can only be set by a host application it is impossible to verify this with Unit tests :(

Fixes #81 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
