### PR TITLE
Ephemeral WebKit Datastore

### DIFF
--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -65,6 +65,12 @@ public final class OAuth: NSObject {
         options?[.autoRefresh] as? Bool ?? false
     }
 
+    /// Convenience var for accessing the useNonPersistentWebDataStore option.
+    @ObservationIgnored
+    var useNonPersistentWebDataStore: Bool {
+        options?[.useNonPersistentWebDataStore] as? Bool ?? false
+    }
+
     /// Combine subscribers.
     @ObservationIgnored
     private var subscribers = Set<AnyCancellable>()
@@ -458,5 +464,9 @@ public extension OAuth.Option {
     /// A key used for custom application identifiers to improve token tagging.
     static let applicationTag: OAuth.Option = .init(rawValue: "applicationTag")
 
+    /// A key used for setting the WKWebsiteDataStore to `nonPersistent()` in the OAWebView.
+    /// This is disabled by default, but this can be turned on to allow developers to use an ephemeral webkit datastore
+    /// that effectively forces a new login attempt every time an authorization flow is started.
+    static let useNonPersistentWebDataStore: OAuth.Option = .init(rawValue: "useNonPersistentWebDataStore")
 }
 

--- a/Sources/OAuthKit/Views/OAWebView.swift
+++ b/Sources/OAuthKit/Views/OAWebView.swift
@@ -15,12 +15,15 @@ import WebKit
 public struct OAWebView {
 
     let oauth: OAuth
-    let view = WKWebView()
+    let view: WKWebView
 
     /// Initializer with the speciifed oauth object,
     /// - Parameter oauth: the oauth object to use
     public init(oauth: OAuth) {
         self.oauth = oauth
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = oauth.useNonPersistentWebDataStore ? WKWebsiteDataStore.nonPersistent() : WKWebsiteDataStore.default()
+        self.view = WKWebView(frame: .zero, configuration: configuration)
     }
 
     public func makeWebView(context: Context) -> WKWebView {

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -38,10 +38,11 @@ final class OAWebViewTests {
     /// Initializer.
     init() async throws {
         tag = "oauthkit.test." + .secureRandom()
-        let options: [OAuth.Option: Sendable] = [.applicationTag: tag, .autoRefresh: false]
+        let options: [OAuth.Option: Sendable] = [.applicationTag: tag, .autoRefresh: false, .useNonPersistentWebDataStore: true]
         oauth = .init(.module, options: options)
         webView = .init(oauth: oauth)
         oauth.urlSession = urlSession
+        #expect(oauth.useNonPersistentWebDataStore == true)
     }
 
     /// Tests the oauth environment values are correct.

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -32,9 +32,10 @@ final class OAuthTests {
     /// Initializer.
     init() async throws {
         tag = "oauthkit.test." + .secureRandom()
-        let options: [OAuth.Option: Sendable] = [.applicationTag: tag, .autoRefresh: true]
+        let options: [OAuth.Option: Sendable] = [.applicationTag: tag, .autoRefresh: true, .useNonPersistentWebDataStore: true]
         oauth = .init(.module, options: options)
         oauth.urlSession = urlSession
+        #expect(oauth.useNonPersistentWebDataStore == true)
     }
 
     /// Tests the initialization with providers.
@@ -51,6 +52,7 @@ final class OAuthTests {
         ]
         let customOAuth: OAuth = .init(providers: providers, options: options)
         #expect(customOAuth.providers.count == 1)
+        #expect(customOAuth.useNonPersistentWebDataStore == false)
     }
 
     /// Tests the custom date extension operator.


### PR DESCRIPTION
# Description

Introduces new OAuth option that allows developers to use an ephemeral webkit datastore that effectively forces a new login attempt every time an authorization flow is started. 

When setting the `[.useNonPersistentWebDataStore: true]` the OAWebView will initialize it's WKWebView with a non persistent data store that only website data in memory, and doesn’t write that data to disk.

```swift
let configuration = WKWebViewConfiguration()
configuration.websiteDataStore = oauth.useNonPersistentWebDataStore ? WKWebsiteDataStore.nonPersistent() : WKWebsiteDataStore.default()
self.view = WKWebView(frame: .zero, configuration: configuration)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
