### PR TITLE
watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         .iOS(.v18),
         .macOS(.v15),
         .tvOS(.v18),
-        .visionOS(.v2)
+        .visionOS(.v2),
+        .watchOS(.v11)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OAuthKit is a contemporary, event-driven Swift Package that utilizes the [Observ
 
 ## OAuthKit Usage
 
-The following is an example of the simplest usage of using OAuthKit in macOS:
+The following is an example of the simplest usage of using OAuthKit across multiple platforms (iOS, macOS, visionOS, tvOS, watchOS):
 
 ```swift
 import OAuthKit
@@ -37,19 +37,23 @@ struct OAuthApp: App {
         }
         .environment(\.oauth, oauth)
         
+        #if canImport(WebKit)
         WindowGroup(id: "oauth") {
             OAWebView(oauth: oauth)
         }
+        #endif
     }
 } 
 
 struct ContentView: View {
     
+    #if canImport(WebKit)
     @Environment(\.openWindow)
     var openWindow
     
     @Environment(\.dismissWindow)
     private var dismissWindow
+    #endif
     
     @Environment(\.oauth)
     var oauth: OAuth
@@ -71,7 +75,8 @@ struct ContentView: View {
                 }
             case .receivedDeviceCode(_, let deviceCode):
                 Text("To login, visit")
-                Text(deviceCode.verificationUri).foregroundStyle(.blue)
+                Text(.init("[\(deviceCode.verificationUri)](\(deviceCode.verificationUri))"))
+                    .foregroundStyle(.blue)
                 Text("and enter the following code:")
                 Text(deviceCode.userCode)
                     .padding()
@@ -88,10 +93,23 @@ struct ContentView: View {
     var providerList: some View {
         List(oauth.providers) { provider in
             Button(provider.id) {
-                // Start the default PKCE flow (.pkce)
-                oauth.authorize(provider: provider)
+                authorize(provider: provider)
             }
         }
+    }
+
+    /// Starts the authorization process for the specified provider.
+    /// - Parameter provider: the provider to begin authorization for
+    private func authorize(provider: OAuth.Provider) {
+        #if canImport(WebKit)
+        // Use the PKCE grantType for iOS, macOS, visionOS
+        let grantType: OAuth.GrantType = .pkce(.init())
+        #else
+        // Use the Device Code grantType for tvOS, watchOS
+        let grantType: OAuth.GrantType = .deviceCode
+        #endif
+        // Start the authorization flow
+        oauth.authorize(provider: provider, grantType: grantType)
     }
     
     /// Reacts to oauth state changes by opening or closing authorization windows.
@@ -101,9 +119,13 @@ struct ContentView: View {
         case .empty, .requestingAccessToken, .requestingDeviceCode:
             break
         case .authorizing, .receivedDeviceCode:
+            #if canImport(WebKit)
             openWindow(id: "oauth")
+            #endif
         case .authorized(_, _):
+            #if canImport(WebKit)
             dismissWindow(id: "oauth")
+            #endif
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 ![iOS 18.0+](https://img.shields.io/badge/iOS-18.0%2B-crimson.svg)
 ![macOS 15.0+](https://img.shields.io/badge/macOS-15.0%2B-skyblue.svg)
 ![tvOS 18.0+](https://img.shields.io/badge/tvOS-18.0%2B-blue.svg)
-![visionOS 2.0+](https://img.shields.io/badge/visionOS-2.0%2B-magenta.svg)
+![visionOS 2.0+](https://img.shields.io/badge/visionOS-2.0%2B-violet.svg)
+![watchOS 11.0+](https://img.shields.io/badge/watchOS-11.0%2B-magenta.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-indigo.svg)](https://opensource.org/licenses/MIT)
 ![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/codefiesta/87655b6e3c89b9198287b2fefbfa641f/raw/oauthkit-coverage.json)
 

--- a/Sources/OAuthKit/Views/OAWebView.swift
+++ b/Sources/OAuthKit/Views/OAWebView.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee on 5/16/24.
 //
 
-#if !os(tvOS)
+#if !os(tvOS) && !os(watchOS)
 import SwiftUI
 import WebKit
 

--- a/Sources/OAuthKit/Views/OAWebView.swift
+++ b/Sources/OAuthKit/Views/OAWebView.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee on 5/16/24.
 //
 
-#if !os(tvOS) && !os(watchOS)
+#if canImport(WebKit)
 import SwiftUI
 import WebKit
 

--- a/Sources/OAuthKit/Views/OAWebViewCoordinator.swift
+++ b/Sources/OAuthKit/Views/OAWebViewCoordinator.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee on 5/16/24.
 //
 
-#if !os(tvOS) && !os(watchOS)
+#if canImport(WebKit)
 import Combine
 import SwiftUI
 import WebKit

--- a/Sources/OAuthKit/Views/OAWebViewCoordinator.swift
+++ b/Sources/OAuthKit/Views/OAWebViewCoordinator.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee on 5/16/24.
 //
 
-#if !os(tvOS)
+#if !os(tvOS) && !os(watchOS)
 import Combine
 import SwiftUI
 import WebKit

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee
 //
 
-#if !os(tvOS) && !os(watchOS)
+#if canImport(WebKit)
 import Foundation
 @testable import OAuthKit
 import SwiftUI

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee
 //
 
-#if !os(tvOS)
+#if !os(tvOS) && !os(watchOS)
 import Foundation
 @testable import OAuthKit
 import SwiftUI

--- a/Tests/OAuthKitTests/OAuthTestWKNavigationAction.swift
+++ b/Tests/OAuthKitTests/OAuthTestWKNavigationAction.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee
 //
 
-#if !os(tvOS) && !os(watchOS)
+#if canImport(WebKit)
 import WebKit
 
 /// OAuth Test WKNavigationAction that can be used for testing

--- a/Tests/OAuthKitTests/OAuthTestWKNavigationAction.swift
+++ b/Tests/OAuthKitTests/OAuthTestWKNavigationAction.swift
@@ -5,7 +5,7 @@
 //  Created by Kevin McKee
 //
 
-#if !os(tvOS)
+#if !os(tvOS) && !os(watchOS)
 import WebKit
 
 /// OAuth Test WKNavigationAction that can be used for testing


### PR DESCRIPTION
# Description

Support for watchOS .v11 is now supported with this change. The macros that were previously testing os versions now simply use the `canImport(Module)` macro. 

```swift 
#if canImport(WebKit)
import WebKit
#endif
```

Fixes #88 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
