### PR TITLE
Local Authentication

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Test
       run: swift test --enable-code-coverage
     - id: coverage
-      uses: codefiesta/swift-coverage-action@0.0.3
+      uses: codefiesta/swift-coverage-action@0.0.4
     - name: badge
       # Only run the badge update if we are pushing to main
       if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ configuration.protocolClasses = [CustomURLProtocol.self]
 let urlSession: URLSession = .init(configuration: configuration)
 
 let options: [OAuth.Option: Sendable] = [.urlSession: urlSession]
-let oauth: OAuth = .init(options: options)
+let oauth: OAuth = .init(.main, options: options)
 ```
 
 ### OAuth initialized with Keychain protection and Private Browsing
 OAuthKit allows you to protect access to your keychain items with biometrics until successful local authentication. If the **.requireAuthenticationWithBiometricsOrCompanion** option is set to true, the device owner will need to be authenticated by biometry or a companion device before keychain items (tokens) can be accessed. 
 
-Developers can also implement private browsing and force a new login attempt every time an authorization flow is started by setting the **.useNonPersistentWebDataStore** to true. This will force the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) to use a .nonPersistent data store that prevents any data from being written to the file system.
+Developers can also implement private browsing by setting the **.useNonPersistentWebDataStore** option to true. This forces the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) used during authorization flows to use a non-persistent data store, preventing data from being written to the file system.
 
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ struct ContentView: View {
 ```
 
 ## OAuthKit Configuration
-By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [Environment](https://developer.apple.com/documentation/swiftui/environment) property wrapper. You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json). OAuthKit provides flexible constructor options that allows developers to customize  how their oauth client is initialized and what features they want to implement. See the [oauth.init(\_:bundle:context:options)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L99) method for details.
+By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [Environment](https://developer.apple.com/documentation/swiftui/environment) property wrapper. You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json). OAuthKit provides flexible constructor options that allows developers to customize  how their oauth client is initialized and what features they want to implement. See the [oauth.init(\_:bundle:options)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L94) method for details.
 
 ### OAuth initialized from main bundle (default)
 ```swift
@@ -150,7 +150,7 @@ If you are building your OAuth Providers programatically (recommended for produc
 
 ```swift
 let providers: [OAuth.Provider] = ...
-let options: [OAuth.Option: Sendable] = [
+let options: [OAuth.Option: Any] = [
     .applicationTag: "com.bundle.identifier",
     .autoRefresh: true,
     .useNonPersistentWebDataStore: true
@@ -167,12 +167,12 @@ let configuration: URLSessionConfiguration = .ephemeral
 configuration.protocolClasses = [CustomURLProtocol.self]
 let urlSession: URLSession = .init(configuration: configuration)
 
-let options: [OAuth.Option: Sendable] = [.urlSession: urlSession]
+let options: [OAuth.Option: Any] = [.urlSession: urlSession]
 let oauth: OAuth = .init(.main, options: options)
 ```
 
 ### OAuth initialized with Keychain protection and Private Browsing
-OAuthKit allows you to protect access to your keychain items with biometrics until successful local authentication. If the **.requireAuthenticationWithBiometricsOrCompanion** option is set to true, the device owner will need to be authenticated by biometry or a companion device before keychain items (tokens) can be accessed. 
+OAuthKit allows you to protect access to your keychain items with biometrics until successful local authentication. If the **.requireAuthenticationWithBiometricsOrCompanion** option is set to true, the device owner will need to be authenticated by biometry or a companion device before keychain items (tokens) can be accessed. OAuthKit uses a default [LAContext](https://developer.apple.com/documentation/localauthentication/lacontext), but if you need fine-grained control while evaluating a user’s identity, pass your own custom [LAContext](https://developer.apple.com/documentation/localauthentication/lacontext) to the options.
 
 Developers can also implement private browsing by setting the **.useNonPersistentWebDataStore** option to true. This forces the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) used during authorization flows to use a non-persistent data store, preventing data from being written to the file system.
 
@@ -182,13 +182,17 @@ Developers can also implement private browsing by setting the **.useNonPersisten
 let configuration: URLSessionConfiguration = .ephemeral
 configuration.protocolClasses = [CustomURLProtocol.self]
 
-let options: [OAuth.Option: Sendable] = [
+// Custom LAContext
+let context: LAContext = .init()
+context.localizedReason = "read tokens from keychain"
+context.localizedFallbackTitle = "Use password"
+context.touchIDAuthenticationAllowableReuseDuration = 10
+
+let options: [OAuth.Option: Any] = [
     .requireAuthenticationWithBiometricsOrCompanion: true,
     .useNonPersistentWebDataStore: true
 ]
-let context: LAContext = .init()
-context.localizedReason = "read tokens from keychain"
-let oauth: OAuth = .init(.main, context: context, options: options)
+let oauth: OAuth = .init(.main, options: options)
 ```
 
 ## OAuthKit Authorization Flows

--- a/README.md
+++ b/README.md
@@ -134,23 +134,43 @@ struct ContentView: View {
 ## OAuthKit Configuration
 By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [Environment](https://developer.apple.com/documentation/swiftui/environment). You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json).
 
+OAuthKit provides flexible constructor options that allows developers to customize  how their oauth client is initialized and what features they want to implement. See the [oauth.init(\_:bundle:context:options)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L101) method for details.
+
+### OAuth initialized from main bundle (default)
 ```swift
 @Environment(\.oauth)
 var oauth: OAuth
 ```
-
+### OAuth initialized from specified bundle
 If you want to customize your OAuth environment or are using modules in your application, you can also specify which bundle to load configure files from:
 
 ```swift
 let oauth: OAuth = .init(.module)
 ```
 
+### OAuth initialized with providers
 If you are building your OAuth Providers programatically (recommended for production applications via a CI build pipeline for security purposes), you can pass providers and options as well.
 
 ```swift
 let providers: [OAuth.Provider] = ...
-let options: [OAuth.Option: Sendable] = [.applicationTag: "com.bundle.identifier", .autoRefresh: true, .useNonPersistentWebDataStore: true]
+let options: [OAuth.Option: Sendable] = [
+    .applicationTag: "com.bundle.identifier",
+    .autoRefresh: true,
+    .useNonPersistentWebDataStore: true
+]
 let oauth: OAuth = .init(providers: providers, options: options)
+```
+### OAuth initialized with keychain protection
+OAuth allows you to protect access to your keychain items with biometrics until successful local authentication. If the **.requireAuthenticationWithBiometricsOrCompanion** option is set to true, the device owner will need to be authenticated by biometry or a companion device before the keychain items can be accessed.
+
+```swift
+let options: [OAuth.Option: Sendable] = [
+    .requireAuthenticationWithBiometricsOrCompanion: true,
+    .useNonPersistentWebDataStore: true
+]
+let context: LAContext = .init()
+context.localizedReason = "read tokens from keychain"
+let oauth: OAuth = .init(.main, context: context, options: options)
 ```
 
 ## OAuthKit Authorization Flows

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ import SwiftUI
 @main
 struct OAuthApp: App {
 
-    /// The observable oauth object 
-    let oauth: OAuth = .init(.main)
+    @Environment(\.oauth)
+    var oauth: OAuth
     
     /// Build the scene body
     var body: some Scene {
@@ -35,7 +35,6 @@ struct OAuthApp: App {
         WindowGroup {
             ContentView()
         }
-        .environment(\.oauth, oauth)
         
         #if canImport(WebKit)
         WindowGroup(id: "oauth") {
@@ -47,6 +46,9 @@ struct OAuthApp: App {
 
 struct ContentView: View {
     
+    @Environment(\.oauth)
+    var oauth: OAuth
+
     #if canImport(WebKit)
     @Environment(\.openWindow)
     var openWindow
@@ -54,9 +56,6 @@ struct ContentView: View {
     @Environment(\.dismissWindow)
     private var dismissWindow
     #endif
-    
-    @Environment(\.oauth)
-    var oauth: OAuth
 
     /// The view body that reacts to oauth state changes
     var body: some View {
@@ -132,7 +131,7 @@ struct ContentView: View {
 ```
 
 ## OAuthKit Configuration
-By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [Environment](https://developer.apple.com/documentation/swiftui/environment). You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json). OAuthKit provides flexible constructor options that allows developers to customize  how their oauth client is initialized and what features they want to implement. See the [oauth.init(\_:bundle:context:options)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L99) method for details.
+By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [Environment](https://developer.apple.com/documentation/swiftui/environment) property wrapper. You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json). OAuthKit provides flexible constructor options that allows developers to customize  how their oauth client is initialized and what features they want to implement. See the [oauth.init(\_:bundle:context:options)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L99) method for details.
 
 ### OAuth initialized from main bundle (default)
 ```swift
@@ -158,8 +157,10 @@ let options: [OAuth.Option: Sendable] = [
 ]
 let oauth: OAuth = .init(providers: providers, options: options)
 ```
-### OAuth initialized with keychain protection
-OAuth allows you to protect access to your keychain items with biometrics until successful local authentication. If the **.requireAuthenticationWithBiometricsOrCompanion** option is set to true, the device owner will need to be authenticated by biometry or a companion device before the keychain items can be accessed.
+### OAuth initialized with keychain protection and private browsing
+OAuthKit allows you to protect access to your keychain items with biometrics until successful local authentication. If the **.requireAuthenticationWithBiometricsOrCompanion** option is set to true, the device owner will need to be authenticated by biometry or a companion device before keychain items (tokens) can be accessed. 
+
+Developers can also implement private browsing and force a new login attempt every time an authorization flow is started by setting the **.useNonPersistentWebDataStore** to true. This will force the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) to use a .nonPersistent data store that prevents any data from being written to the file system.
 
 ```swift
 let options: [OAuth.Option: Sendable] = [

--- a/README.md
+++ b/README.md
@@ -157,12 +157,31 @@ let options: [OAuth.Option: Sendable] = [
 ]
 let oauth: OAuth = .init(providers: providers, options: options)
 ```
-### OAuth initialized with keychain protection and private browsing
+
+### OAuth initialized with custom URLSession
+To support custom protocols or URL schemes that your app supports, developers can pass a custom **.urlSession** option that will allow the configuration of custom [URLProtocol](https://developer.apple.com/documentation/foundation/urlprotocol) classes that can handle the loading of protocol-specific URL data.
+
+```swift
+// Custom URLSession
+let configuration: URLSessionConfiguration = .ephemeral
+configuration.protocolClasses = [CustomURLProtocol.self]
+let urlSession: URLSession = .init(configuration: configuration)
+
+let options: [OAuth.Option: Sendable] = [.urlSession: urlSession]
+let oauth: OAuth = .init(options: options)
+```
+
+### OAuth initialized with Keychain protection and Private Browsing
 OAuthKit allows you to protect access to your keychain items with biometrics until successful local authentication. If the **.requireAuthenticationWithBiometricsOrCompanion** option is set to true, the device owner will need to be authenticated by biometry or a companion device before keychain items (tokens) can be accessed. 
 
 Developers can also implement private browsing and force a new login attempt every time an authorization flow is started by setting the **.useNonPersistentWebDataStore** to true. This will force the [WKWebView](https://developer.apple.com/documentation/webkit/wkwebview) to use a .nonPersistent data store that prevents any data from being written to the file system.
 
+
 ```swift
+// Custom url session
+let configuration: URLSessionConfiguration = .ephemeral
+configuration.protocolClasses = [CustomURLProtocol.self]
+
 let options: [OAuth.Option: Sendable] = [
     .requireAuthenticationWithBiometricsOrCompanion: true,
     .useNonPersistentWebDataStore: true

--- a/README.md
+++ b/README.md
@@ -173,13 +173,14 @@ let oauth: OAuth = .init(.main, context: context, options: options)
 ```
 
 ## OAuthKit Authorization Flows
-OAuth 2.0 workflows are started by calling the [oauth.authorize(provider:grantType:)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L127) method.
+OAuth 2.0 authorization flows are started by calling the [oauth.authorize(provider:grantType:)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L127) method.
+
+A good resource to help understand the detailed steps involved in OAuth 2.0 authorization flows can be found on the [OAuth 2.0 Playground](https://www.oauth.com/playground/index.html).
 
 ```swift
 oauth.authorize(provider: provider, grantType: grantType)
 ``` 
 
-A good resource to help understand the detailed steps involved in OAuth 2.0 workflows can be found on the [OAuth 2.0 Playground](https://www.oauth.com/playground/index.html).
 
 ### OAuth 2.0 Authorization Code Flow
 The [Authorization Code](https://oauth.net/2/grant-types/authorization-code/) grant type is used by confidential and public clients to exchange an authorization code for an access token. It is recommended that all clients use the [PKCE](#oauth-20-pkce-flow) extension with this flow as well to provide better security.

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -271,8 +271,9 @@ private extension OAuth {
                 }
             }
         }
+        
         #else
-        debugPrint("⚠️ Misconfigured option: `requireAuthenticationWithBiometricsOrCompanion` is set to true but the current platform does not support biometrics authentication. ")
+        debugPrint("⚠️ Misconfigured option: `requireAuthenticationWithBiometricsOrCompanion` is set to true but the current platform does not support biometric authentication.")
         loadAuthorizations()
         #endif
     }

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -240,7 +240,7 @@ private extension OAuth {
         if context.canEvaluatePolicy(policy, error: &error) {
             context.evaluatePolicy(policy, localizedReason: localizedReason) { [weak self] success, error in
                 guard let self else { return }
-                Task { @MainActor in
+                Task(priority: .high) { @MainActor in
                     if success {
                         self.loadAuthorizations()
                     }
@@ -304,7 +304,7 @@ private extension OAuth {
                     tasks.append(task)
                 } else {
                     // Execute the task immediately
-                    Task {
+                    Task(priority: .high) {
                         await refreshToken(provider: provider)
                     }
                 }

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -271,7 +271,6 @@ private extension OAuth {
                 }
             }
         }
-        
         #else
         debugPrint("⚠️ Misconfigured option: `requireAuthenticationWithBiometricsOrCompanion` is set to true but the current platform does not support biometric authentication.")
         loadAuthorizations()

--- a/Tests/OAuthKitTests/KeychainTests.swift
+++ b/Tests/OAuthKitTests/KeychainTests.swift
@@ -26,7 +26,7 @@ final class KeychainTests {
     @Test("Storing keychain values")
     func whenStoring() async throws {
         let key = "Github"
-        let token: OAuth.Token = .init(accessToken: "1234", refreshToken: nil, expiresIn: 3600, scope: "email", type: "Bearer")
+        let token: OAuth.Token = .init(accessToken: .secureRandom(), refreshToken: .secureRandom(), expiresIn: 3600, scope: "email", type: "Bearer")
 
         let inserted = try! keychain.set(token, for: key)
         #expect(inserted == true)

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -38,7 +38,7 @@ final class OAWebViewTests {
     /// Initializer.
     init() async throws {
         tag = "oauthkit.test." + .secureRandom()
-        let options: [OAuth.Option: Sendable] = [
+        let options: [OAuth.Option: Any] = [
             .applicationTag: tag,
             .autoRefresh: false,
             .useNonPersistentWebDataStore: true,

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -18,7 +18,7 @@ final class OAWebViewTests {
 
     /// The mock url session that overrides the protocol classes with `OAuthTestURLProtocol`
     /// that will intercept all outbound requests and return mocked test data.
-    private lazy var urlSession: URLSession = {
+    private static let urlSession: URLSession = {
         let configuration: URLSessionConfiguration = .ephemeral
         configuration.protocolClasses = [OAuthTestURLProtocol.self]
         return .init(configuration: configuration)
@@ -38,10 +38,14 @@ final class OAWebViewTests {
     /// Initializer.
     init() async throws {
         tag = "oauthkit.test." + .secureRandom()
-        let options: [OAuth.Option: Sendable] = [.applicationTag: tag, .autoRefresh: false, .useNonPersistentWebDataStore: true]
+        let options: [OAuth.Option: Sendable] = [
+            .applicationTag: tag,
+            .autoRefresh: false,
+            .useNonPersistentWebDataStore: true,
+            .urlSession: Self.urlSession
+        ]
         oauth = .init(.module, options: options)
         webView = .init(oauth: oauth)
-        oauth.urlSession = urlSession
         #expect(oauth.useNonPersistentWebDataStore == true)
     }
 

--- a/Tests/OAuthKitTests/OAuthTestLAContext.swift
+++ b/Tests/OAuthKitTests/OAuthTestLAContext.swift
@@ -1,0 +1,33 @@
+//
+//  OAuthTestLAContext.swift
+//  OAuthKit
+//
+//  Created by Kevin McKee
+//
+
+import Foundation
+import LocalAuthentication
+
+/// Provides an LAContext that can be safely used in tests that have set `.requireAuthenticationWithBiometricsOrCompanion` to true.
+class OAuthTestLAContext: LAContext {
+
+    var canEvaluatePolicy: Bool = true
+    var evaluatePolicyError: Error?
+
+    /// Returns the localized reason for biometric or companion device authentication.
+    override var localizedReason: String  {
+        set { }
+        get {
+            return "test keychain access"
+        }
+    }
+
+    /// Overrides the evaluate policy to always succeed.
+    /// - Parameters:
+    ///   - policy: the policy to evaludate
+    ///   - localizedReason: the reason for access
+    ///   - reply: the evaluation reply.
+    override func evaluatePolicy(_ policy: LAPolicy, localizedReason: String?, reply: @escaping (Bool, Error?) -> Void) {
+        reply(true, nil)
+    }
+}

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -5,6 +5,7 @@
 //  Created by Kevin McKee
 //
 import Foundation
+import LocalAuthentication
 @testable import OAuthKit
 import Testing
 
@@ -58,16 +59,14 @@ final class OAuthTests {
     @Test("When Requiring Local Authentication")
     func whenRequiringAuthenticationWithBiometricsOrCompanion() async throws {
         let appTag: String = .secureRandom()
-        let localAuthenticationReason = "to unlock device"
         let options: [OAuth.Option: Sendable] = [
             .applicationTag: appTag,
             .requireAuthenticationWithBiometricsOrCompanion: true,
-            .requireAuthenticationWithBiometricsOrCompanionReason: localAuthenticationReason,
             .autoRefresh: false]
-        let customOAuth: OAuth = .init(.module, options: options)
+        let context: LAContext = OAuthTestLAContext()
+        let customOAuth: OAuth = .init(.module, context: context, options: options)
         #expect(customOAuth.providers.isNotEmpty)
         #expect(customOAuth.requireAuthenticationWithBiometricsOrCompanion == true)
-        #expect(customOAuth.requireAuthenticationWithBiometricsOrCompanionReason == localAuthenticationReason)
     }
 
     /// Tests the custom date extension operator.

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -55,6 +55,21 @@ final class OAuthTests {
         #expect(customOAuth.useNonPersistentWebDataStore == false)
     }
 
+    @Test("When Requiring Local Authentication")
+    func whenRequiringAuthenticationWithBiometricsOrCompanion() async throws {
+        let appTag: String = .secureRandom()
+        let localAuthenticationReason = "to unlock device"
+        let options: [OAuth.Option: Sendable] = [
+            .applicationTag: appTag,
+            .requireAuthenticationWithBiometricsOrCompanion: true,
+            .requireAuthenticationWithBiometricsOrCompanionReason: localAuthenticationReason,
+            .autoRefresh: false]
+        let customOAuth: OAuth = .init(.module, options: options)
+        #expect(customOAuth.providers.isNotEmpty)
+        #expect(customOAuth.requireAuthenticationWithBiometricsOrCompanion == true)
+        #expect(customOAuth.requireAuthenticationWithBiometricsOrCompanionReason == localAuthenticationReason)
+    }
+
     /// Tests the custom date extension operator.
     @Test("Expiring tokens")
     func whenExpiring() async throws {

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -69,6 +69,22 @@ final class OAuthTests {
         #expect(customOAuth.requireAuthenticationWithBiometricsOrCompanion == true)
     }
 
+    @Test("When Restoring Authorizations")
+    func whenRestoringAuthorizations() async throws {
+
+        let key = provider.id
+        let token: OAuth.Token = .init(accessToken: .secureRandom(), refreshToken: .secureRandom(), expiresIn: 3600, scope: "email", type: "Bearer")
+        let auth: OAuth.Authorization = .init(issuer: provider.id, token: token)
+        let inserted = try! keychain.set(auth, for: key)
+        #expect(inserted == true)
+
+        let options: [OAuth.Option: Sendable] = [.applicationTag: tag, .autoRefresh: true, .useNonPersistentWebDataStore: true]
+        let restoredOAuth: OAuth = .init(.module, options: options)
+        #expect(restoredOAuth.state == .authorized(provider, auth))
+        keychain.clear()
+    }
+
+
     /// Tests the custom date extension operator.
     @Test("Expiring tokens")
     func whenExpiring() async throws {

--- a/Tests/OAuthKitTests/OAuthTests.swift
+++ b/Tests/OAuthKitTests/OAuthTests.swift
@@ -34,10 +34,10 @@ final class OAuthTests {
     init() async throws {
         tag = "oauthkit.test." + .secureRandom()
 
-        let options: [OAuth.Option: Sendable] = [
+        let options: [OAuth.Option: Any] = [
             .applicationTag: tag, .autoRefresh: true,
             .useNonPersistentWebDataStore: true,
-            .urlSession: Self.urlSession
+            .urlSession: Self.urlSession,
         ]
         oauth = .init(.module, options: options)
         #expect(oauth.useNonPersistentWebDataStore == true)
@@ -48,7 +48,7 @@ final class OAuthTests {
     @Test("When Initializing")
     func whenInitializing() async throws {
         let appTag: String = .secureRandom()
-        let options: [OAuth.Option: Sendable] = [
+        let options: [OAuth.Option: Any] = [
             .applicationTag: appTag,
             .autoRefresh: true,
             .urlSession: Self.urlSession,
@@ -69,12 +69,13 @@ final class OAuthTests {
     @Test("When Requiring Local Authentication")
     func whenRequiringAuthenticationWithBiometricsOrCompanion() async throws {
         let appTag: String = .secureRandom()
-        let options: [OAuth.Option: Sendable] = [
-            .applicationTag: appTag,
-            .requireAuthenticationWithBiometricsOrCompanion: true,
-            .autoRefresh: false]
         let context: LAContext = OAuthTestLAContext()
-        let customOAuth: OAuth = .init(.module, context: context, options: options)
+        let options: [OAuth.Option: Any] = [
+            .applicationTag: appTag,
+            .localAuthentication: context,
+            .requireAuthenticationWithBiometricsOrCompanion: true,
+            .autoRefresh: true]
+        let customOAuth: OAuth = .init(.module, options: options)
         #expect(customOAuth.providers.isNotEmpty)
         #expect(customOAuth.requireAuthenticationWithBiometricsOrCompanion == true)
     }
@@ -87,7 +88,7 @@ final class OAuthTests {
         let inserted = try! keychain.set(auth, for: key)
         #expect(inserted == true)
 
-        let options: [OAuth.Option: Sendable] = [
+        let options: [OAuth.Option: Any] = [
             .applicationTag: tag,
             .autoRefresh: false,
             .useNonPersistentWebDataStore: true,
@@ -226,7 +227,7 @@ final class OAuthTests {
         let inserted = try! keychain.set(auth, for: key)
         #expect(inserted == true)
 
-        let options: [OAuth.Option: Sendable] = [
+        let options: [OAuth.Option: Any] = [
             .applicationTag: tag,
             .autoRefresh: true,
             .useNonPersistentWebDataStore: true,


### PR DESCRIPTION
# Description

Provides options for protecting the Keychain items until successful local authentication has been achieved with biometrics or companion device.

### 📣 Changes

1. The options parameter in the `oauth.init(bundle:options:)` and `oauth.init(providers:options:)` now accept [OAuth.Option: Any] instead of [OAuth.Option: Sendable]. The change to the more flexible `Any` allows the OAuth object to cast instances of any type instead of objects that only conform to Sendable (LAContext) . Also, options are now no longer held as a hash inside the OAuth object but rather safely unpacked into their expected types. 
2. This was an intentional decision to allow greater flexibility for developers to configure an `LAContext` for biometric authentication and also allow for improved testing feasibility. This route was chosed over adding macros around platform specific constructors as the `LAContext` is not provided for all target platforms.

Fixes #93 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
