### PR TITLE
OAuth+Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ struct ContentView: View {
 ```
 
 ## OAuthKit Configuration
-By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [Environment](https://developer.apple.com/documentation/swiftui/environment) property wrapper. You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json). OAuthKit provides flexible constructor options that allows developers to customize  how their oauth client is initialized and what features they want to implement. See the [oauth.init(\_:bundle:options)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L94) method for details.
+By default, the easiest way to configure OAuthKit is to simply drop an `oauth.json` file into your main bundle and it will get automatically loaded into your swift application and available as an [Environment](https://developer.apple.com/documentation/swiftui/environment) property wrapper. You can find an example `oauth.json` file [here](https://github.com/codefiesta/OAuthKit/blob/main/Tests/OAuthKitTests/Resources/oauth.json). OAuthKit provides flexible constructor options that allows developers to customize  how their oauth client is initialized and what features they want to implement. See the [oauth.init(\_:bundle:options)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L98) method for details.
 
 ### OAuth initialized from main bundle (default)
 ```swift
@@ -192,7 +192,7 @@ let oauth: OAuth = .init(.main, options: options)
 ```
 
 ## OAuthKit Authorization Flows
-OAuth 2.0 authorization flows are started by calling the [oauth.authorize(provider:grantType:)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L127) method.
+OAuth 2.0 authorization flows are started by calling the [oauth.authorize(provider:grantType:)](https://github.com/codefiesta/OAuthKit/blob/main/Sources/OAuthKit/OAuth.swift#L117) method.
 
 A good resource to help understand the detailed steps involved in OAuth 2.0 authorization flows can be found on the [OAuth 2.0 Playground](https://www.oauth.com/playground/index.html).
 

--- a/Sources/OAuthKit/Extensions/Data+Extensions.swift
+++ b/Sources/OAuthKit/Extensions/Data+Extensions.swift
@@ -46,5 +46,4 @@ extension Data {
         _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
         return Data(bytes: &bytes, count: bytes.count)
     }
-
 }

--- a/Sources/OAuthKit/Extensions/Date+Extensions.swift
+++ b/Sources/OAuthKit/Extensions/Date+Extensions.swift
@@ -17,5 +17,4 @@ public extension Date {
     static func - (lhs: Date, rhs: Date) -> TimeInterval {
         return lhs.timeIntervalSinceReferenceDate - rhs.timeIntervalSinceReferenceDate
     }
-
 }

--- a/Sources/OAuthKit/Extensions/Digest+Extensions.swift
+++ b/Sources/OAuthKit/Extensions/Digest+Extensions.swift
@@ -38,5 +38,4 @@ extension Digest {
             .replacingOccurrences(of: "=", with: "")
             .trimmingCharacters(in: .whitespaces)
     }
-
 }

--- a/Sources/OAuthKit/OAuth+Authorization.swift
+++ b/Sources/OAuthKit/OAuth+Authorization.swift
@@ -42,5 +42,4 @@ extension OAuth {
             return issued.addingTimeInterval(TimeInterval(expiresIn))
         }
     }
-
 }

--- a/Sources/OAuthKit/OAuth+Option.swift
+++ b/Sources/OAuthKit/OAuth+Option.swift
@@ -1,0 +1,50 @@
+//
+//  OAuth+Option.swift
+//  OAuthKit
+//
+//  Created by Kevin McKee
+//
+
+import Foundation
+
+extension OAuth {
+
+    /// Keys and values used to specify loading or runtime options.
+    public struct Option: Hashable, RawRepresentable, Sendable {
+
+        /// The option raw value.
+        public var rawValue: String
+
+        /// Initializer
+        /// - Parameter rawValue: the option raw value
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+    }
+}
+
+public extension OAuth.Option {
+
+    /// A key used for custom application identifiers to improve token tagging.
+    static let applicationTag: OAuth.Option = .init(rawValue: "applicationTag")
+
+    /// A key used to specify whether tokens should be automatically refreshed or not.
+    static let autoRefresh: OAuth.Option = .init(rawValue: "autoRefresh")
+
+    /// A key used for providing a custom local authentication object.
+    static let localAuthentication: OAuth.Option = .init(rawValue: "localAuthentication")
+
+    /// A key used for determining if the keychain should be protected with biometrics until successful local authentication.
+    /// If set to true, the device owner will need to be authenticated by biometry or a companion device before the keychain items can be accessed.
+    /// Important: developers should set the requireAuthenticationWithBiometricsOrCompanionReason that will be eventually displayed in the authentication dialog.
+    static let requireAuthenticationWithBiometricsOrCompanion: OAuth.Option = . init(rawValue: "requireAuthenticationWithBiometricsOrCompanion")
+
+    /// A key used for providing a custom url session.
+    static let urlSession: OAuth.Option = .init(rawValue: "urlSession")
+
+    /// A key used for setting the WKWebsiteDataStore to `nonPersistent()` in the OAWebView.
+    /// This is disabled by default, but this can be turned on to allow developers to use an ephemeral webkit datastore
+    /// that effectively implements private browsing and forces a new login attempt every time an authorization flow is started.
+    static let useNonPersistentWebDataStore: OAuth.Option = .init(rawValue: "useNonPersistentWebDataStore")
+}
+

--- a/Sources/OAuthKit/OAuth+Request.swift
+++ b/Sources/OAuthKit/OAuth+Request.swift
@@ -258,7 +258,6 @@ extension OAuth {
             return queryItems
         }
     }
-
 }
 
 fileprivate extension URLQueryItem {

--- a/Sources/OAuthKit/OAuth+Token.swift
+++ b/Sources/OAuthKit/OAuth+Token.swift
@@ -60,5 +60,4 @@ extension OAuth {
             case openIDToken = "id_token"
         }
     }
-
 }

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -45,17 +45,20 @@ public final class OAuth {
     /// The url session to use for communicating with providers.
     @ObservationIgnored
     public var urlSession: URLSession = .init(configuration: .ephemeral)
-    @ObservationIgnored
-    private var tasks = [Task<(), any Error>]()
-    @ObservationIgnored
-    private let networkMonitor = NetworkMonitor()
+
     @ObservationIgnored
     var keychain: Keychain = .default
 
-#if os(macOS) || os(iOS) || os(visionOS)
+    #if os(macOS) || os(iOS) || os(visionOS)
     @ObservationIgnored
     var context: LAContext = .init()
-#endif
+    #endif
+
+    @ObservationIgnored
+    private var tasks = [Task<(), any Error>]()
+
+    @ObservationIgnored
+    private let networkMonitor = NetworkMonitor()
 
     /// Configuration option determining if tokens should be auto refreshed or not.
     @ObservationIgnored

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -20,10 +20,13 @@ private let defaultAuthenticationWithBiometricsOrCompanionReason = "unlock keych
 
 /// Provides an enum of oauth errors.
 public enum OAError: Error {
-    case unknown
+    /// An error occurred while building a request url
     case malformedURL
+    /// An error occurred while loading data from a request
     case badResponse
+    /// Unable to decode a response from a provider into an expected type.
     case decoding
+    /// Unable to write data to the keychain
     case keychain
 }
 
@@ -31,20 +34,7 @@ public enum OAError: Error {
 /// See: https://datatracker.ietf.org/doc/html/rfc6749
 @MainActor
 @Observable
-public final class OAuth: NSObject {
-
-    /// Keys and values used to specify loading or runtime options.
-    public struct Option: Hashable, Equatable, RawRepresentable, Sendable {
-
-        /// The option raw value.
-        public var rawValue: String
-
-        /// Initializer
-        /// - Parameter rawValue: the option raw value
-        public init(rawValue: String) {
-            self.rawValue = rawValue
-        }
-    }
+public final class OAuth {
 
     /// A published list of available OAuth providers to choose from.
     public var providers = [Provider]()
@@ -62,10 +52,10 @@ public final class OAuth: NSObject {
     @ObservationIgnored
     var keychain: Keychain = .default
 
-    #if os(macOS) || os(iOS) || os(visionOS)
+#if os(macOS) || os(iOS) || os(visionOS)
     @ObservationIgnored
     var context: LAContext = .init()
-    #endif
+#endif
 
     /// Configuration option determining if tokens should be auto refreshed or not.
     @ObservationIgnored
@@ -94,7 +84,6 @@ public final class OAuth: NSObject {
     ///   - providers: the list of oauth providers
     ///   - options: the configuration options to apply
     public init(providers: [Provider] = [Provider](), options: [Option: Any]? = nil) {
-        super.init()
         self.providers = providers
         configure(options)
     }
@@ -104,7 +93,6 @@ public final class OAuth: NSObject {
     ///   - bundle: the bundle to load the oauth provider configuration information from.
     ///   - options: the configuration options to apply
     public init(_ bundle: Bundle, options: [Option: Any]? = nil) {
-        super.init()
         self.providers = loadProviders(bundle)
         configure(options)
     }
@@ -524,32 +512,3 @@ extension OAuth {
         publish(state: .authorized(provider, authorization))
     }
 }
-
-
-// MARK: Options
-
-public extension OAuth.Option {
-
-    /// A key used for custom application identifiers to improve token tagging.
-    static let applicationTag: OAuth.Option = .init(rawValue: "applicationTag")
-
-    /// A key used to specify whether tokens should be automatically refreshed or not.
-    static let autoRefresh: OAuth.Option = .init(rawValue: "autoRefresh")
-
-    /// A key used for providing a custom local authentication object.
-    static let localAuthentication: OAuth.Option = .init(rawValue: "localAuthentication")
-
-    /// A key used for determining if the keychain should be protected with biometrics until successful local authentication.
-    /// If set to true, the device owner will need to be authenticated by biometry or a companion device before the keychain items can be accessed.
-    /// Important: developers should set the requireAuthenticationWithBiometricsOrCompanionReason that will be eventually displayed in the authentication dialog.
-    static let requireAuthenticationWithBiometricsOrCompanion: OAuth.Option = . init(rawValue: "requireAuthenticationWithBiometricsOrCompanion")
-
-    /// A key used for providing a custom url session.
-    static let urlSession: OAuth.Option = .init(rawValue: "urlSession")
-
-    /// A key used for setting the WKWebsiteDataStore to `nonPersistent()` in the OAWebView.
-    /// This is disabled by default, but this can be turned on to allow developers to use an ephemeral webkit datastore
-    /// that effectively implements private browsing and forces a new login attempt every time an authorization flow is started.
-    static let useNonPersistentWebDataStore: OAuth.Option = .init(rawValue: "useNonPersistentWebDataStore")
-}
-

--- a/Tests/OAuthKitTests/CodableTests.swift
+++ b/Tests/OAuthKitTests/CodableTests.swift
@@ -58,5 +58,4 @@ struct CodableTests {
         #expect(deviceCode.expiration != nil)
         #expect(deviceCode.interval == decoded.interval)
     }
-
 }

--- a/Tests/OAuthKitTests/OAWebViewTests.swift
+++ b/Tests/OAuthKitTests/OAWebViewTests.swift
@@ -56,7 +56,8 @@ final class OAWebViewTests {
         var values: EnvironmentValues = .init()
         values.oauth = oauth
         let environmentOAuth = values.oauth
-        #expect(environmentOAuth == oauth)
+        #expect(environmentOAuth.providers == oauth.providers)
+        #expect(environmentOAuth.state == oauth.state)
     }
 
     /// Tests the OAWebViewCoordinator coordinator policy decisions.
@@ -65,7 +66,7 @@ final class OAWebViewTests {
 
         // 1) Bad Request Expectations
         let coordinator: OAWebViewCoordinator = webView.makeCoordinator()
-        #expect(coordinator.oauth == oauth)
+        #expect(coordinator.oauth.state == oauth.state)
         let wkWebView = webView.view
 
         var urlRequest: URLRequest = .init(url: URL(string: "https://github.com/codefiesta/OAuthKit")!)
@@ -108,7 +109,7 @@ final class OAWebViewTests {
 
         // 1) Bad Request Expectations
         let coordinator: OAWebViewCoordinator = webView.makeCoordinator()
-        #expect(coordinator.oauth == oauth)
+        #expect(coordinator.oauth.state == oauth.state)
         let wkWebView = webView.view
 
         var urlRequest: URLRequest = .init(url: URL(string: "https://github.com/codefiesta/OAuthKit")!)


### PR DESCRIPTION
# Description

- OAuth no longer inherits from NSObject.
- Moves the `OAuth+Option` into it's own extension.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
