### PR TITLE
@Observable NetworkMonitor

### DIFF
--- a/Sources/OAuthKit/Network/NetworkMonitor.swift
+++ b/Sources/OAuthKit/Network/NetworkMonitor.swift
@@ -5,43 +5,46 @@
 //  Created by Kevin McKee on 5/30/24.
 //
 
-import Combine
 import Network
+import Observation
 
 private let queueLabel = "oauthkit.NetworkMonitor"
 
 /// A type that broadcasts network reachability via Combine event publishing.
-@MainActor final class NetworkMonitor {
+@MainActor
+@Observable
+final class NetworkMonitor {
 
-    /// The private pass through publisher.
-    private var publisher = PassthroughSubject<Bool, Never>()
-
-    /// Provides a pass through subject used to broadcast events to downstream subscribers.
-    /// The subject will automatically drop events if there are no subscribers, or its current demand is zero.
-    public lazy var networkStatus = publisher.eraseToAnyPublisher()
-
+    @ObservationIgnored
     private let pathMonitor = NWPathMonitor()
-    private let queue = DispatchQueue(label: queueLabel)
 
     /// Returns true if the network has an available wifi interface.
     var onWifi = false
     /// Returns true if the network has an available cellular interface.
     var onCellular = false
+    /// Returns true if the network has an wired ethernet interface.
+    var onWiredEthernet = false
 
-    /// Initializer that starts the network monitor and begins publishing updates.
-    init() {
-        pathMonitor.pathUpdateHandler = { [weak self] path in
-            guard let self else { return }
-            Task { @MainActor in
-                self.handle(path: path)
-            }
-        }
-        pathMonitor.start(queue: queue)
+    /// Returns true if the network is online with any available interface.
+    var isOnline: Bool {
+        onWifi || onCellular || onWiredEthernet
     }
 
-    func handle(path: NWPath) {
+    /// Initializer.
+    init() { }
+
+    /// Starts the network monitor (conforms to AsyncSequence).
+    func start() async {
+        for await path in pathMonitor {
+            handle(path: path)
+        }
+    }
+
+    /// Handles the snapshot view of the network path state.
+    /// - Parameter path: the snapshot view of the network path state
+    private func handle(path: NWPath) {
         onWifi = path.usesInterfaceType(.wifi)
         onCellular = path.usesInterfaceType(.cellular)
-        publisher.send(path.status == .satisfied)
+        onWiredEthernet = path.usesInterfaceType(.wiredEthernet)
     }
 }

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Kevin McKee on 5/14/24.
 //
-import Combine
 import Foundation
 #if canImport(LocalAuthentication)
 import LocalAuthentication
@@ -73,10 +72,6 @@ public final class OAuth {
     /// If set to true, the device owner will need to be authenticated by biometry or a companion device before the keychain items can be accessed.
     @ObservationIgnored
     var requireAuthenticationWithBiometricsOrCompanion: Bool = false
-
-    /// Combine subscribers.
-    @ObservationIgnored
-    private var subscribers = Set<AnyCancellable>()
 
     /// The json decoder
     @ObservationIgnored
@@ -229,7 +224,7 @@ private extension OAuth {
                 self.keychain = .init(applicationTag)
             }
         }
-        subscribe()
+        monitor()
         restore()
     }
 
@@ -270,12 +265,11 @@ private extension OAuth {
         #endif
     }
 
-    /// Subsribes to event publishers.
-    func subscribe() {
-        // Subscribe to network status events
-        networkMonitor.networkStatus.sink { (_) in
-            // TODO: Add Handler
-        }.store(in: &subscribers)
+    /// Starts the network monitor.
+    func monitor() {
+        Task {
+            await networkMonitor.start()
+        }
     }
 
     /// Publishes state on the main thread.


### PR DESCRIPTION
# Description

Converts the NetworkMonitor to [@Observable](https://developer.apple.com/documentation/Observation/Observable()) and removes the Combine publishers to rely on network state changes. The NetworkMonitor now has an `start() async` method that asynchronously iterates through the internal [NWPathMonitor](https://developer.apple.com/documentation/network/nwpathmonitor) [NWPath](https://developer.apple.com/documentation/network/nwpath) elements as it conforms to [AsyncSequence](https://developer.apple.com/documentation/swift/asyncsequence).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
