### PR TITLE
Singleton Network Monitor

### DIFF
--- a/Sources/OAuthKit/Network/NetworkMonitor.swift
+++ b/Sources/OAuthKit/Network/NetworkMonitor.swift
@@ -19,6 +19,9 @@ public final class NetworkMonitor: Sendable {
     @ObservationIgnored
     private let pathMonitor = NWPathMonitor()
 
+    /// Flag indicating if monitoring is currently active or not.
+    public var isMonitoring = false
+
     /// Returns true if the network has an available wifi interface.
     public var onWifi = false
     /// Returns true if the network has an available cellular interface.
@@ -36,6 +39,8 @@ public final class NetworkMonitor: Sendable {
 
     /// Starts the network monitor (conforms to AsyncSequence).
     public func start() async {
+        guard !isMonitoring else { return }
+        isMonitoring.toggle()
         for await path in pathMonitor {
             handle(path: path)
         }

--- a/Sources/OAuthKit/Network/NetworkMonitor.swift
+++ b/Sources/OAuthKit/Network/NetworkMonitor.swift
@@ -11,7 +11,10 @@ import Observation
 /// An  `Observable` type that publishes network reachability information.
 @MainActor
 @Observable
-public final class NetworkMonitor {
+public final class NetworkMonitor: Sendable {
+
+    // The shared singleton network monitor.
+    public static let shared: NetworkMonitor = .init()
 
     @ObservationIgnored
     private let pathMonitor = NWPathMonitor()
@@ -29,7 +32,7 @@ public final class NetworkMonitor {
     }
 
     /// Initializer.
-    public init() { }
+    private init() { }
 
     /// Starts the network monitor (conforms to AsyncSequence).
     public func start() async {

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -57,7 +57,7 @@ public final class OAuth: Sendable {
     private var tasks = [Task<(), any Error>]()
 
     @ObservationIgnored
-    private let networkMonitor = NetworkMonitor()
+    private let networkMonitor: NetworkMonitor = .shared
 
     /// Configuration option determining if tokens should be auto refreshed or not.
     @ObservationIgnored

--- a/Tests/OAuthKitTests/UtilityTests.swift
+++ b/Tests/OAuthKitTests/UtilityTests.swift
@@ -153,7 +153,7 @@ struct UtilityTests {
     @MainActor
     @Test("Network Monitor")
     func whenNetworkMonitoring() async throws {
-        let monitor = NetworkMonitor()
+        let monitor: NetworkMonitor = .shared
         #expect(monitor.isOnline == false)
         withObservationTracking {
             _ = monitor.isOnline

--- a/Tests/OAuthKitTests/UtilityTests.swift
+++ b/Tests/OAuthKitTests/UtilityTests.swift
@@ -162,8 +162,15 @@ struct UtilityTests {
                 #expect(monitor.isOnline)
             }
         }
-        Task {
+        Task { @MainActor in
             await monitor.start()
+            #expect(monitor.isMonitoring)
+        }
+        // The second call to monitor.start() should simply bail as monitoring
+        // is already happening and not toggle the internal `isMonitoring` flag.
+        Task { @MainActor in
+            await monitor.start()
+            #expect(monitor.isMonitoring)
         }
     }
 }


### PR DESCRIPTION
# Description

- NetworkMonitor is now a singleton as it doesn't  make sense to multiple instances running inside the same container.
- NetworkMonitor is now conforming to `Sendable` to safely pass  from one concurrency domain to another.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
