### PR TITLE
Swift 6.2 + 26.0 APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,11 +6,11 @@ import PackageDescription
 let package = Package(
     name: "OAuthKit",
     platforms: [
-        .iOS(.v18),
-        .macOS(.v15),
-        .tvOS(.v18),
-        .visionOS(.v2),
-        .watchOS(.v11)
+        .iOS(.v26),
+        .macOS(.v26),
+        .tvOS(.v26),
+        .visionOS(.v26),
+        .watchOS(.v26)
     ],
     products: [
         .library(
@@ -32,7 +32,7 @@ let package = Package(
         .testTarget(
             name: "OAuthKitTests",
             dependencies: ["OAuthKit"],
-            resources: [.process("Resources/")]
+            resources: [.process("Resources")]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Key features include:
 
 ## OAuthKit Installation
 
-OAuthKit can be installed using [Swift Package Manager](https://www.swift.org/documentation/package-manager/). If you need to build with Swift Tools 6.1 and Apple APIs > `26.0` use version `1.5.1`.
+OAuthKit can be installed using [Swift Package Manager](https://www.swift.org/documentation/package-manager/). If you need to build with Swift Tools `6.1` and Apple APIs > `26.0` use version [1.5.1](https://github.com/codefiesta/OAuthKit/releases/tag/1.5.1).
 
 ```swift
 dependencies: [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build](https://github.com/codefiesta/OAuthKit/actions/workflows/swift.yml/badge.svg)
-![Xcode 26.0+](https://img.shields.io/badge/Xcode-26.0%2B-gold.svg)
-![Swift 6.2+](https://img.shields.io/badge/Swift-6.2%2B-tomato.svg)
+![Swift 6.2+](https://img.shields.io/badge/Swift-6.2%2B-gold.svg)
+![Xcode 26.0+](https://img.shields.io/badge/Xcode-26.0%2B-tomato.svg)
 ![iOS 26.0+](https://img.shields.io/badge/iOS-26.0%2B-crimson.svg)
 ![macOS 26.0+](https://img.shields.io/badge/macOS-26.0%2B-skyblue.svg)
 ![tvOS 26.0+](https://img.shields.io/badge/tvOS-26.0%2B-blue.svg)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![Build](https://github.com/codefiesta/OAuthKit/actions/workflows/swift.yml/badge.svg)
 ![Xcode 26.0+](https://img.shields.io/badge/Xcode-26.0%2B-gold.svg)
-![Swift 6.1+](https://img.shields.io/badge/Swift-6.1%2B-tomato.svg)
-![iOS 18.0+](https://img.shields.io/badge/iOS-18.0%2B-crimson.svg)
-![macOS 15.0+](https://img.shields.io/badge/macOS-15.0%2B-skyblue.svg)
-![tvOS 18.0+](https://img.shields.io/badge/tvOS-18.0%2B-blue.svg)
-![visionOS 2.0+](https://img.shields.io/badge/visionOS-2.0%2B-violet.svg)
-![watchOS 11.0+](https://img.shields.io/badge/watchOS-11.0%2B-magenta.svg)
+![Swift 6.2+](https://img.shields.io/badge/Swift-6.2%2B-tomato.svg)
+![iOS 26.0+](https://img.shields.io/badge/iOS-26.0%2B-crimson.svg)
+![macOS 26.0+](https://img.shields.io/badge/macOS-26.0%2B-skyblue.svg)
+![tvOS 26.0+](https://img.shields.io/badge/tvOS-26.0%2B-blue.svg)
+![visionOS 26.0+](https://img.shields.io/badge/visionOS-26.0%2B-violet.svg)
+![watchOS 26.0+](https://img.shields.io/badge/watchOS-26.0%2B-magenta.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-indigo.svg)](https://opensource.org/licenses/MIT)
 ![Code Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/codefiesta/87655b6e3c89b9198287b2fefbfa641f/raw/oauthkit-coverage.json)
 
@@ -36,11 +36,11 @@ Key features include:
 
 ## OAuthKit Installation
 
-OAuthKit can be installed using [Swift Package Manager](https://www.swift.org/documentation/package-manager/):
+OAuthKit can be installed using [Swift Package Manager](https://www.swift.org/documentation/package-manager/). If you need to build with Swift Tools 6.1 and Apple APIs > `26.0` use version `1.5.1`.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/codefiesta/OAuthKit", from: "1.5.0")
+    .package(url: "https://github.com/codefiesta/OAuthKit", from: "2.0.0")
 ]
 ```
 


### PR DESCRIPTION
# Description

- Apple OS versions 26.0
- Swift Tools version  6.2

For developers who require Swift Tools 6.1 or Apple APIs prior to 26.0 use release use version [1.5.1](https://github.com/codefiesta/OAuthKit/releases/tag/1.5.1).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
