### PR TITLE
Swift 6.1 Macro Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /.build
 /Packages
 xcuserdata/
+.dependencies
+.derivedData
 DerivedData/
 .swiftpm/
 .swiftpm/configuration/registries.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Code Fiesta
+Copyright (c) 2026 Code Fiesta
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Sources/OAuthKit/OAuth.swift
+++ b/Sources/OAuthKit/OAuth.swift
@@ -328,7 +328,13 @@ private extension OAuth {
     ///   - operation: the operation to be run immediately upon entering the task.
     func task(priority: TaskPriority = .high, operation: sending @escaping @isolated(any) () async throws -> Void) {
         if #available(macOS 26, iOS 26, watchOS 26, tvOS 26, visionOS 26, *) {
+            #if compiler(>=6.2)
+            // Swfit 6.2 compilers and above
             Task.immediate(operation: operation)
+            #else
+            // Swift 6.1 compiler
+            Task(priority: priority, operation: operation)
+            #endif
         } else {
             Task(priority: priority, operation: operation)
         }


### PR DESCRIPTION
# Description

Provides fix for developers using Xcode 16.3 and Swift 6.1 compilers. After looking at the [Swift Package Index Build Results](https://swiftpackageindex.com/codefiesta/OAuthKit/builds) it appears the `@available` check isn't sufficent. 

## Fix and Testing

You'll need to [download Xcode 16.3](https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_16.3/Xcode_16.3.xip) and use xcrun from the command line (You won't be able to run the old Xcode version on Tahoe). Run the following command 

```bash
env DEVELOPER_DIR=/PATH_TO_DOWNLOAD/Xcode_16.3.app xcrun swift build --arch arm64
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
