### PR TITLE
Workflow Action Updates

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
   
-    runs-on: macos-26
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v7.0.1

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-26
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.1
     - name: Install SwiftLint
       run: brew install swiftlint
     - name: Lint

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -26,11 +26,11 @@ jobs:
     - name: Test
       run: swift test --enable-code-coverage
     - id: coverage
-      uses: codefiesta/swift-coverage-action@0.0.4
+      uses: codefiesta/swift-coverage-action@0.0.5
     - name: badge
       # Only run the badge update if we are pushing to main
       if: github.ref == 'refs/heads/main'
-      uses: schneegans/dynamic-badges-action@v1.7.0
+      uses: schneegans/dynamic-badges-action@v1.9.0
       with:
         auth: ${{secrets.GIST_SECRET}}
         gistID: 87655b6e3c89b9198287b2fefbfa641f


### PR DESCRIPTION
# Description

Bumping workflow actions to use latest versions as well as the `macos-26` -> `macos-latest`.

- swift-coverage-action@`0.0.4` ->  swift-coverage-action@`0.0.5`
- dynamic-badges-action@`v1.7.0` -> dynamic-badges-action@`v1.9.0`
- checkout@v`4` -> checkout@v`7.0.1`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
